### PR TITLE
t_byte_vector backward compatibility

### DIFF
--- a/uvvm_util/src/string_methods_pkg.vhd
+++ b/uvvm_util/src/string_methods_pkg.vhd
@@ -229,13 +229,6 @@ package string_methods_pkg is
     ) return string;
 
   function to_string(
-    val     : t_byte_array;
-    radix   : t_radix        := HEX_BIN_IF_INVALID;
-    format  : t_format_zeros := KEEP_LEADING_0;  -- | SKIP_LEADING_0
-    prefix  : t_radix_prefix := EXCL_RADIX -- Insert radix prefix in string?
-    ) return string;
-
-  function to_string(
     val     : t_slv_array;
     radix   : t_radix        := HEX_BIN_IF_INVALID;
     format  : t_format_zeros := KEEP_LEADING_0;  -- | SKIP_LEADING_0
@@ -1094,50 +1087,6 @@ package body string_methods_pkg is
 
     else -- No decimal convertion: May be treated as slv, so use the slv overload
       return to_string(std_logic_vector(val), radix, format, prefix);
-    end if;
-  end;
-
-  function to_string(
-    val     : t_byte_array;
-    radix   : t_radix        := HEX_BIN_IF_INVALID;
-    format  : t_format_zeros := KEEP_LEADING_0;  -- | SKIP_LEADING_0
-    prefix  : t_radix_prefix := EXCL_RADIX -- Insert radix prefix in string?
-    ) return string is
-    variable v_line         : line;
-    variable v_result       : string(1 to 2 +              -- parentheses
-                                     2*(val'length - 1) +  -- commas
-                                     26 * val'length);     -- 26 is max length of returned value from slv to_string()
-    variable v_width        : natural;
-  begin
-    if val'length = 0 then
-      -- Value length is zero,
-      -- return empty string.
-      return "";
-    elsif val'length = 1 then
-      -- Value length is 1
-      -- Return the single value it contains
-      return to_string(val(val'low), radix, format, prefix);
-    else
-      -- Value length more than 1
-      -- Comma-separate all array members and return
-      write(v_line, string'("("));
-
-      for i in val'range loop
-        write(v_line, to_string(val(i), radix, format, prefix));
-
-        if i < val'right and val'ascending then
-          write(v_line, string'(", "));
-        elsif i > val'right and not val'ascending then
-          write(v_line, string'(", "));
-        end if;
-      end loop;
-
-      write(v_line, string'(")"));
-
-      v_width := v_line'length;
-      v_result(1 to v_width) := v_line.all;
-      deallocate(v_line);
-      return v_result(1 to v_width);
     end if;
   end;
 

--- a/uvvm_util/src/types_pkg.vhd
+++ b/uvvm_util/src/types_pkg.vhd
@@ -35,8 +35,8 @@ package types_pkg is
 
   type t_natural_array  is array (natural range <>) of natural;
   type t_integer_array  is array (natural range <>) of integer;
-  type t_byte_array     is array (natural range <>) of std_logic_vector(7 downto 0);
   type t_slv_array      is array (natural range <>) of std_logic_vector;
+  subtype t_byte_array  is t_slv_array(open)(7 downto 0);
   type t_signed_array   is array (natural range <>) of signed;
   type t_unsigned_array is array (natural range <>) of unsigned;
 


### PR DESCRIPTION
Hej

While the change for issue #35 helps for the ambiguity when using literals, it breaks those code that uses t_byte_vector.
However, as I mentioned, this is easy avoidable by using a subtype.

I am using this change with questasim. The plan was to test it with GHDL as well, but GHDL does not work due to the unconstrained arrays in the records right now.
I cannot test it with further simulators, we don't have them.

Best regards,
emanuel