### PR TITLE
Remove wait cycle in UART BFM when UART parity is set to PARITY_NONE

### DIFF
--- a/bitvis_vip_uart/src/uart_bfm_pkg.vhd
+++ b/bitvis_vip_uart/src/uart_bfm_pkg.vhd
@@ -224,7 +224,10 @@ package body uart_bfm_pkg is
         tx <= odd_parity(data_value);
       end if;
     end if;
-    wait for config.bit_time;
+
+    if (config.parity /= PARITY_NONE) then
+      wait for config.bit_time;
+    end if;
 
 
     -- Set stop bits


### PR DESCRIPTION
The UART BFM transmit procedure was always waiting for one bit period in the parity slot, even when parity was disabled. This commit fixes the extra wait issue. 