### PR TITLE
fix inconsistencies between declaration and body

### DIFF
--- a/bitvis_vip_axi/src/axi_bfm_pkg.vhd
+++ b/bitvis_vip_axi/src/axi_bfm_pkg.vhd
@@ -222,11 +222,11 @@ package axi_bfm_pkg is
   ) return std_logic_vector;
 
   function bytes_to_axsize(
-    bytes : positive
+    constant bytes : positive
   ) return std_logic_vector;
 
   function axlock_to_sl(
-    axlock : t_axlock
+    constant axlock : t_axlock
   ) return std_logic;
 
   ------------------------------------------


### PR DESCRIPTION
In Riviera-PRO 2020.04 the build fails with
```
# 
# Compiling bitvis_vip_axi source
# 
# eval vcom  -2008 -nowarn COMP96_0564 -nowarn COMP96_0048 -dbg -work bitvis_vip_axi  uvvm_test/UVVM/script/../bitvis_vip_axi/script/../src/axi_bfm_pkg.vhd
# ACOM: File: uvvm_test/UVVM/script/../bitvis_vip_axi/script/../src/axi_bfm_pkg.vhd
# ACOM: Compile Package "axi_bfm_pkg"
# ACOM: Compile Package Body "axi_bfm_pkg"
# ACOM: The currently compiled unit contains subprogram specifications with minor inconsistencies between the declaration and the body.
# ACOM: Use -relax to ignore such inconsistencies.
# ACOM: Error: COMP96_0321: uvvm_test/UVVM/bitvis_vip_axi/src/axi_bfm_pkg.vhd : (417, 29): Subprogram specification of the body must conform to the subprogram specification of the declaration.
# ACOM: Error: COMP96_0321: uvvm_test/UVVM/bitvis_vip_axi/src/axi_bfm_pkg.vhd : (446, 22): Subprogram specification of the body must conform to the subprogram specification of the declaration.
```

This fixes the mentioned inconsistencies and the build succeeds.