### PR TITLE
Axistream: Add data_length from VVC command to transaction_info

### DIFF
--- a/bitvis_vip_axistream/src/transaction_pkg.vhd
+++ b/bitvis_vip_axistream/src/transaction_pkg.vhd
@@ -85,6 +85,7 @@ package transaction_pkg is
   type t_base_transaction is record
     operation           : t_operation;
     data_array          : t_byte_array(0 to C_VVC_CMD_DATA_MAX_BYTES-1);
+    data_length         : integer range 0 to C_VVC_CMD_DATA_MAX_BYTES;
     user_array          : t_user_array(0 to C_VVC_CMD_DATA_MAX_WORDS-1);
     strb_array          : t_strb_array(0 to C_VVC_CMD_DATA_MAX_WORDS-1);
     id_array            : t_id_array(0 to C_VVC_CMD_DATA_MAX_WORDS-1);
@@ -96,6 +97,7 @@ package transaction_pkg is
   constant C_BASE_TRANSACTION_SET_DEFAULT : t_base_transaction := (
     operation           => NO_OPERATION,
     data_array          => (others => (others => '0')),
+    data_length         => 0,
     user_array          => (others => (others => '0')),
     strb_array          => (others => (others => '0')),
     id_array            => (others => (others => '0')),

--- a/bitvis_vip_axistream/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_axistream/src/vvc_methods_pkg.vhd
@@ -935,6 +935,7 @@ package body vvc_methods_pkg is
       when TRANSMIT | RECEIVE | EXPECT =>
         vvc_transaction_info_group.bt.operation                             := vvc_cmd.operation;
         vvc_transaction_info_group.bt.data_array                            := vvc_cmd.data_array;
+        vvc_transaction_info_group.bt.data_length                           := vvc_cmd.data_array_length;
         vvc_transaction_info_group.bt.user_array                            := vvc_cmd.user_array;
         vvc_transaction_info_group.bt.strb_array                            := vvc_cmd.strb_array;
         vvc_transaction_info_group.bt.id_array                              := vvc_cmd.id_array;


### PR DESCRIPTION
When writing a DUT model I needed to have access to the actually transmitted data length of the Axistream master VVC. Thus I added it to the vvc_transaction_info.

Please review if this makes sense, or show me a better way how to solve this. I might have missed something in the VVC as I'm very new to UVVM.