### PR TITLE
axistream_receive: Add logging of frames

### DIFF
--- a/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
+++ b/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
@@ -1573,7 +1573,7 @@ package body axistream_bfm_pkg is
     data_length := v_byte_cnt;
 
     -- Log the received frame
-    log(ID_FRAME_DATA, v_proc_call.all & "=> Rx Frame (" & to_string(v_byte_cnt) & "B) " & to_string(data_array) & ". " & add_msg_delimiter(msg), scope, msg_id_panel);
+    log(ID_PACKET_PAYLOAD, v_proc_call.all & "=> Rx Frame (" & to_string(v_byte_cnt) & "B) " & to_string(data_array) & ". " & add_msg_delimiter(msg), scope, msg_id_panel);
 
     -- Check if there was a timeout or it was successful
     if v_timeout then

--- a/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
+++ b/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
@@ -1572,6 +1572,9 @@ package body axistream_bfm_pkg is
     -- Set the number of bytes received
     data_length := v_byte_cnt;
 
+    -- Log the received frame
+    log(ID_FRAME_DATA, v_proc_call.all & "=> Rx Frame (" & to_string(v_byte_cnt) & "B) " & to_string(data_array) & ". " & add_msg_delimiter(msg), scope, msg_id_panel);
+
     -- Check if there was a timeout or it was successful
     if v_timeout then
       alert(config.max_wait_cycles_severity, v_proc_call.all & "=> Failed. Timeout while waiting for valid data. " & add_msg_delimiter(msg), scope);

--- a/uvvm_util/src/adaptations_pkg.vhd
+++ b/uvvm_util/src/adaptations_pkg.vhd
@@ -121,6 +121,7 @@ package adaptations_pkg is
     ID_PACKET_DATA,           -- Notify that a packet data has been transmitted or received. It also writes packet data
     ID_PACKET_CHECKSUM,       -- Notify that a packet checksum has been transmitted or received
     ID_PACKET_GAP,            -- Notify that an interpacket gap is in process
+    ID_PACKET_PAYLOAD,        -- Notify that a packet payload has been transmitted or received
     -- Frame Ids, roughest granularity of packet data
     ID_FRAME_INITIATE,        -- Notify that a frame is about to be transmitted or received
     ID_FRAME_COMPLETE,        -- Notify that a frame has been transmitted or received


### PR DESCRIPTION
When debugging axistream transaction it is very helpful to be able to look at the entire received frame. Using ID_PACKET_DATA for this purpose is too verbose in my opinion. 