### PR TITLE
Fix performance issue with frame logging.

### DIFF
--- a/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
+++ b/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
@@ -1573,7 +1573,9 @@ package body axistream_bfm_pkg is
     data_length := v_byte_cnt;
 
     -- Log the received frame
-    log(ID_PACKET_PAYLOAD, v_proc_call.all & "=> Rx Frame (" & to_string(v_byte_cnt) & "B) " & to_string(data_array) & ". " & add_msg_delimiter(msg), scope, msg_id_panel);
+    if is_log_msg_enabled(ID_PACKET_PAYLOAD, msg_id_panel) then -- large frames may affect performance
+      log(ID_PACKET_PAYLOAD, v_proc_call.all & "=> Rx Frame (" & to_string(v_byte_cnt) & "B) " & to_string(data_array) & ". " & add_msg_delimiter(msg), scope, msg_id_panel);
+    end if;
 
     -- Check if there was a timeout or it was successful
     if v_timeout then


### PR DESCRIPTION
When running with large frames the to_string(data_array) would use up
all available memory and crash modelsim.