### PR TITLE
Make support

### DIFF
--- a/MAKE_SUPPORT.md
+++ b/MAKE_SUPPORT.md
@@ -1,0 +1,38 @@
+# GNU Make Support
+Experimental support for using GNU Make to drive simulation of the `bitvis_uart` and `bitvis_irqc` examples is now included. The `script` subdirectory of these examples now includes a Makefile which can be used to compile, simulate and view the resulting waveform in **GTKWave**. The supported simulators are **GHDL**, **NVC**, **ModelSim** and **Questa**.
+
+To try it out, open a terminal, navigate to the `script` subdirectory of the relevant example, then run `make`, specifying the simulator as the target. For example, on Windows/MSYS2, in a Windows Command Prompt:
+
+    cd C:\work\UVVM\bitvis_uart\script
+    make ghdl
+
+Replace `C:\work\UVVM` with the correct path to your clone of the UVVM repository.
+
+The heavy lifting is done by a couple of Makefile includes (`multisim.mk` and `example.mk`) and a shell script (`vcd2gtkw.sh`) which are located in the main `script` directory, along with `Makefile_template` which can be used as a starting point for using Makefiles in your own projects.
+
+### Notes:
+1. On Windows, MSYS2 is recommended. Use `pacman` to install `make` (required) and `git` (recommended).
+2. At present, precompiled UVVM libraries are required. See the simulator specific notes below for details.
+
+## Simulator Specific Notes
+
+### GHDL
+To precompile the UVVM libraries and VIPs, run the `compile-uvvm.sh` script which is located in the `vendors` subdirectory of the GHDL libraries directory. On Linux, the default location of this directory is `/usr/local/lib/ghdl`; on Windows/MSYS2, the default location is `C:\msys64\mingw64\lib\ghdl`.
+
+### NVC
+UVVM support in NVC is partially complete, but sufficient for the examples.
+
+To precompile the UVVM libraries and VIPs, run the following command:
+
+    nvc --install uvvm
+
+### ModelSim/Questa
+The `compile_all.do` script located in the main script directory can be used to precompile the UVVM libraries and VIPs. Choose (or create) an appropriate directory for user precompiled libraries, and create a `uvvm` subdirectory under it. This subdirectory is the 2nd argument to the script. For example, on Windows/MSYS2, enter the following command in a Windows Command Prompt:
+
+    vsim -c -do "do C:/work/UVVM/script/compile_all.do C:/work/UVVM/script C:/work/.simlib/uvvm; exit"
+
+* Replace `C:/work/UVVM` with the correct path to your clone of the UVVM repository.
+* Replace `C:/work/.simlib` with the correct path to your precompiled libraries directory.
+* Note the forward slashes!
+
+The `multisim.mk` Makefile include assumes that precompiled libraries are located in the `.simlib` subdirectory of the **home** directory. You can change this by setting the `SIM_LIB_PATH` variable in your Makefile.

--- a/bitvis_irqc/script/Makefile
+++ b/bitvis_irqc/script/Makefile
@@ -1,0 +1,2 @@
+REPO_ROOT=$(shell git rev-parse --show-toplevel)
+include $(REPO_ROOT)/script/examples.mk

--- a/bitvis_irqc/script/Makefile
+++ b/bitvis_irqc/script/Makefile
@@ -1,2 +1,2 @@
 REPO_ROOT=$(shell git rev-parse --show-toplevel)
-include $(REPO_ROOT)/script/examples.mk
+include $(REPO_ROOT)/script/example.mk

--- a/bitvis_uart/script/Makefile
+++ b/bitvis_uart/script/Makefile
@@ -1,0 +1,2 @@
+REPO_ROOT=$(shell git rev-parse --show-toplevel)
+include $(REPO_ROOT)/script/examples.mk

--- a/bitvis_uart/script/Makefile
+++ b/bitvis_uart/script/Makefile
@@ -1,2 +1,2 @@
 REPO_ROOT=$(shell git rev-parse --show-toplevel)
-include $(REPO_ROOT)/script/examples.mk
+include $(REPO_ROOT)/script/example.mk

--- a/script/Makefile_template
+++ b/script/Makefile_template
@@ -1,0 +1,41 @@
+# Makefile_template
+# example of how to use multisim.mk
+
+# work library name
+WORK:=my_design
+
+# source files in compilation order
+DUT_FILES=\
+    ../src/my_pkg.vhd \
+    ../src/my_design.vhd
+TB_FILES=\
+    ../tb/my_th.vhd \
+    ../tb/my_tb.vhd
+SRC=$(DUT_FILES) $(TB_FILES)
+
+# top unit name
+TOP=my_tb
+
+# option: relaxed VHDL rules e.g. impure behaviour by pure functions
+VHDL_RELAXED=TRUE
+
+# option: suppress IEEE assertions e.g. metavalues in to_integer
+#VHDL_SUPPRESS_IEEE_ASSERTS=TRUE
+
+# option: waveform output filename
+WAVE=wave.vcd
+
+# option: create waveform save file with signals from all levels of hierarchy
+WAVE_LEVELS=0
+
+# option: launch waveform viewer after simulation
+WAVE_VIEW=TRUE
+
+# include multisim.mk here
+include $(REPO_ROOT)/script/multisim.mk
+
+# compile
+$(eval $(call COMPILE,$(WORK),$(SRC)))
+
+# simulate
+$(eval $(call RUN,$(TOP),))

--- a/script/example.mk
+++ b/script/example.mk
@@ -1,4 +1,4 @@
-# examples.mk - an include for makefiles for UVVM examples
+# example.mk - an include for makefiles for UVVM examples
 
 ifeq ($(REPO_ROOT),)
 REPO_ROOT=$(shell git rev-parse --show-toplevel)
@@ -15,8 +15,11 @@ SRC=\
     $(shell ls $(TB_PATH)/*th.vhd ls 2> /dev/null) \
     $(shell ls $(TB_PATH)/*tb.vhd)
 
-SIM_VHDL_RELAXED=TRUE
-#SIM_VHDL_SUPPRESS_IEEE_ASSERTS=TRUE
+VHDL_RELAXED=TRUE
+#VHDL_SUPPRESS_IEEE_ASSERTS=TRUE
+WAVE=wave.vcd
+WAVE_LEVELS=0
+WAVE_VIEW=TRUE
 
 include $(REPO_ROOT)/script/multisim.mk
 $(eval $(call COMPILE,$(WORK),$(SRC)))

--- a/script/examples.mk
+++ b/script/examples.mk
@@ -5,8 +5,8 @@ REPO_ROOT=$(shell git rev-parse --show-toplevel)
 endif
 DESIGN_NAME:=$(shell basename `dirname $(shell pwd)`)
 DESIGN_PATH:=$(REPO_ROOT)/$(DESIGN_NAME)
+WORK:=$(word 3,$(shell head -n 1 compile_order.txt))
 SCRIPT_PATH:=$(DESIGN_PATH)/script
-DUT_LIB:=$(word 3,$(shell head -n 1 compile_order.txt))
 DUT_FILES:=$(shell tail -n +2 compile_order.txt)
 TB_PATH:=$(DESIGN_PATH)/tb
 TOP=$(notdir $(basename $(shell ls $(TB_PATH)/*tb.vhd)))
@@ -19,5 +19,5 @@ SIM_VHDL_RELAXED=TRUE
 #SIM_VHDL_SUPPRESS_IEEE_ASSERTS=TRUE
 
 include $(REPO_ROOT)/script/multisim.mk
-$(eval $(call COMPILE,$(DUT_LIB),$(SRC)))
+$(eval $(call COMPILE,$(WORK),$(SRC)))
 $(eval $(call RUN,$(TOP),))

--- a/script/examples.mk
+++ b/script/examples.mk
@@ -1,0 +1,23 @@
+# examples.mk - an include for makefiles for UVVM examples
+
+ifeq ($(REPO_ROOT),)
+REPO_ROOT=$(shell git rev-parse --show-toplevel)
+endif
+DESIGN_NAME:=$(shell basename `dirname $(shell pwd)`)
+DESIGN_PATH:=$(REPO_ROOT)/$(DESIGN_NAME)
+SCRIPT_PATH:=$(DESIGN_PATH)/script
+DUT_LIB:=$(word 3,$(shell head -n 1 compile_order.txt))
+DUT_FILES:=$(shell tail -n +2 compile_order.txt)
+TB_PATH:=$(DESIGN_PATH)/tb
+TOP=$(notdir $(basename $(shell ls $(TB_PATH)/*tb.vhd)))
+SRC=\
+    $(addprefix $(SCRIPT_PATH)/, $(DUT_FILES)) \
+    $(shell ls $(TB_PATH)/*th.vhd ls 2> /dev/null) \
+    $(shell ls $(TB_PATH)/*tb.vhd)
+
+SIM_VHDL_RELAXED=TRUE
+#SIM_VHDL_SUPPRESS_IEEE_ASSERTS=TRUE
+
+include $(REPO_ROOT)/script/multisim.mk
+$(eval $(call COMPILE,$(DUT_LIB),$(SRC)))
+$(eval $(call RUN,$(TOP),))

--- a/script/multisim.mk
+++ b/script/multisim.mk
@@ -1,0 +1,211 @@
+################################################################################
+# multisim.mk - simple support for driving UVVM simulations from makefiles.
+# Supported simulators: GHDL, NVC, ModelSim, Questa
+# Assumes that UVVM libraries are precompiled!
+# Supported platforms:
+#	Linux
+#	Windows MSYS2-MinGW64 shell (GHDL and NVC only)
+#	Windows Command Prompt (with MSYS2 binaries including make itself in path)
+# Include in your makefile before compile and simulate steps.
+################################################################################
+# check for supported simulator
+
+SIM=$(MAKECMDGOALS)
+ifeq ($(filter $(SIM),ghdl nvc modelsim questa clean),)
+INDENT:=$(subst ,,	)
+all:
+	$(info )
+	$(info Please specify your chosen simulator after 'make' as follows:)
+	$(info make <simulator>)
+	$(info )
+	$(info Supported options for <simulator>:)
+	$(info $(INDENT)ghdl)
+	$(info $(INDENT)nvc)
+	$(info $(INDENT)questa)
+	$(info $(INDENT)modelsim)
+	$(info )
+	$(error Unspecified or unsupported simulator)
+endif
+
+################################################################################
+# MSYS2 definitions
+
+ifeq ($(OS),Windows_NT)
+# default location of MSYS2 if not already defined
+ifeq ($(MSYS2),)
+MSYS2:=C:\msys64
+endif
+MSYS2_MINGW64:=$(MSYS2)\mingw64
+endif
+
+################################################################################
+# GHDL definitions
+
+ifeq ($(SIM),ghdl)
+
+# default GHDL installation path, if not already defined
+ifeq ($(OS),Windows_NT)
+ifeq ($(GHDL_INSTALL_PATH),)
+GHDL_INSTALL_PATH:=$(MSYS2_MINGW64)
+endif
+else
+GHDL_INSTALL_PATH:=/usr/local
+endif
+
+# precompiled vendor libraries, if not already defined
+ifeq ($(GHDL_LIBS),)
+GHDL_LIBS=uvvm xilinx-vivado intel
+endif
+
+# GHDL executable
+GHDL=ghdl
+
+#-P$(GHDL_INSTALL_PATH)/lib/ghdl 
+
+# GHDL options: analysis, elaboration, run
+GHDL_AOPTS=--std=08 -fsynopsys -Wno-hide -Wno-shared $(addprefix -P$(GHDL_INSTALL_PATH)/lib/ghdl/vendors/,$(GHDL_LIBS))
+GHDL_EOPTS=--std=08 -fsynopsys $(addprefix -P$(GHDL_INSTALL_PATH)/lib/ghdl/vendors/,$(GHDL_LIBS))
+GHDL_ROPTS=--unbuffered --max-stack-alloc=0
+ifeq ($(SIM_VHDL_RELAXED),TRUE)
+GHDL_AOPTS:=$(GHDL_AOPTS) -frelaxed
+GHDL_EOPTS:=$(GHDL_EOPTS) -frelaxed
+endif
+ifeq ($(SIM_VHDL_SUPPRESS_IEEE_ASSERTS),TRUE)
+GHDL_ROPTS:=$(GHDL_ROPTS) --ieee-asserts=disable
+endif
+
+# GHDL compilation command
+define COMPILE_CMD
+$1:
+	$(GHDL) -a --work=$1 $(GHDL_AOPTS) $2
+endef
+
+# GHDL simulation command
+define RUN_CMD
+ghdl: $1
+	$(GHDL) --elab-run --work=$1 $(GHDL_EOPTS) $2 $(GHDL_ROPTS) $(strip $(addprefix -g,$(subst ;, ,$3)))
+endef
+
+endif
+
+################################################################################
+# NVC definitions
+
+ifeq ($(SIM),nvc)
+
+# NVC executable
+NVC=nvc
+
+# NVC options: global, analysis, elaboration, run
+NVC_GOPTS=--std=08
+NVC_AOPTS=
+NVC_EOPTS=
+NVC_ROPTS=
+ifeq ($(VHDL_RELAXED),TRUE)
+	NVC_AOPTS:=$(NVC_AOPTS) --relaxed
+endif
+ifeq ($(VHDL_SUPPRESS_IEEE_ASSERTS),TRUE)
+	NVC_ROPTS:=$(NVC_ROPTS) --ieee-warnings=off
+endif
+
+# NVC compilation command
+define COMPILE_CMD
+$1:
+	$(NVC) $(NVC_GOPTS) --work=$1 -a $(NVC_AOPTS) $2
+endef
+
+# NVC simulation command
+define RUN_CMD
+nvc: $1
+	$(NVC) $(NVC_GOPTS) --work=$1 -e $2 $(NVC_EOPTS) $(strip $(addprefix -g,$(subst ;, ,$3)))
+	$(NVC) $(NVC_GOPTS) --work=$1 -r $2 $(NVC_ROPTS)
+endef
+
+endif
+
+################################################################################
+# ModelSim/Questa definitions
+
+ifneq ($(filter $(SIM),modelsim questa),)
+
+# default path to user compiled libraries, if not already defined
+ifeq ($(OS),Windows_NT)
+ifeq ($(HOME),)
+SIM_LIB_PATH=/c/work/.simlib
+else
+SIM_LIB_PATH=$(shell cygpath $(HOME))/.simlib
+endif
+else
+SIM_LIB_PATH=~/.simlib
+endif
+
+# user compiled libraries
+ifeq ($(GHDL_LIBS),)
+GHDL_LIBS=uvvm xilinx-vivado intel
+endif
+
+VMAP=vmap
+VCOM=vcom
+VCOMOPTS=-2008 -explicit -vopt -stats=none
+VSIM=vsim
+VSIMOPTS=-t ps -c -onfinish stop -do "onfinish exit; run -all; exit"
+ifeq ($(VHDL_SUPPRESS_IEEE_ASSERTS),TRUE)
+	VSIMOPTS:=-do "set NumericStdNoWarnings 1" $(VSIMOPTS)
+endif
+
+modelsim.ini: $(SIM_LIB_PATH)/uvvm/*
+	$(foreach L,$?,$(VMAP) $(notdir $L) $L;)
+
+# ModelSim/Questa compilation command
+define COMPILE_CMD
+$1: | modelsim.ini
+	$(VCOM) -work $1 $(VCOMOPTS) $2
+endef
+
+# ModelSim/Questa simulation command
+define RUN_CMD
+modelsim questa: $1
+	$(VSIM) -work $1 $(VSIMOPTS) $2 $(strip $(addprefix -g,$(subst ;, ,$3)))
+endef
+
+endif
+
+################################################################################
+# functions to call simulator specific commands
+
+# COMPILE: $1 = work library name, $2 = sources
+define COMPILE
+ifeq ($(WORK),)
+WORK=$1
+endif
+$(eval $(call COMPILE_CMD,$1,$2))
+endef
+
+# RUN: $1 = work library name, $2 = top unit name, $3 = runtime generics
+# generics example:
+#  MyIntVal=123;MyStrVal="hello"
+define RUN
+ifeq ($(TOP),)
+TOP=$1
+endif
+$(eval $(call RUN_CMD,$(WORK),$1,$2))
+endef
+
+################################################################################
+# cleanup (user makefile may add more)
+
+# UVVM
+clean::
+	rm _*.txt
+
+# GHDL
+clean::
+	rm -f $(TOP) $(TOP).exe $(WORK)-obj08.cf $(wildcard *.o)
+
+# NVC, ModelSim, Questa
+clean::
+	rm -rf $(WORK)
+
+# ModelSim, Questa
+clean::
+	rm -f modelsim.ini transcript

--- a/script/multisim.mk
+++ b/script/multisim.mk
@@ -101,10 +101,10 @@ NVC_GOPTS=--std=08
 NVC_AOPTS=
 NVC_EOPTS=
 NVC_ROPTS=
-ifeq ($(VHDL_RELAXED),TRUE)
+ifeq ($(SIM_VHDL_RELAXED),TRUE)
 	NVC_AOPTS:=$(NVC_AOPTS) --relaxed
 endif
-ifeq ($(VHDL_SUPPRESS_IEEE_ASSERTS),TRUE)
+ifeq ($(SIM_VHDL_SUPPRESS_IEEE_ASSERTS),TRUE)
 	NVC_ROPTS:=$(NVC_ROPTS) --ieee-warnings=off
 endif
 
@@ -149,7 +149,7 @@ VCOM=vcom
 VCOMOPTS=-2008 -explicit -vopt -stats=none
 VSIM=vsim
 VSIMOPTS=-t ps -c -onfinish stop -do "onfinish exit; run -all; exit"
-ifeq ($(VHDL_SUPPRESS_IEEE_ASSERTS),TRUE)
+ifeq ($(SIM_VHDL_SUPPRESS_IEEE_ASSERTS),TRUE)
 	VSIMOPTS:=-do "set NumericStdNoWarnings 1" $(VSIMOPTS)
 endif
 

--- a/script/vcd2gtkw.sh
+++ b/script/vcd2gtkw.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# vcd2gtkw.sh
+#
+# This script creates a .gtkw (waveform save file) from a .vcd (value change
+# dump). Waves are added in the order they are found in the VCD, which normally
+# matches the order of port, signal declarations etc in the design source. Wave
+# colours are cycled as the hierarchy levels are traversed.
+#
+# Arguments:
+#  $1 : vcd filename
+#  $2 : gtkw filename
+#  $3 : (optional) hierarchy levels to descend, 0 = all (default if omitted)
+
+vcd_filename=$1
+gtkw_filename=$2
+if [ -z "$3" ]; then
+    levels=0;
+else
+    levels=$3
+fi
+echo "vcd2gtkw.sh: $1 -> $2 (levels = $3)"
+echo "[\*] vcd2gtkw.sh: $1 -> $2 (levels = $3)" > $gtkw_filename
+declare -a hlevel=() # current hierarchy level
+scope="" # current scope name
+declare -a waves=() # waves gathered for current scope
+color=7
+wave_name=""
+function join_with { local IFS="$1"; shift; echo "$*"; }
+while read -r line; do # read file line by line
+    if [[ ${line:0:1} == "\$" ]]; then
+        IFS=' ' read -ra line_tokens <<< "$line" # split line into tokens
+        cmd=${line_tokens[0]} # cmd = 1st token
+        cmd="${cmd:1}" # strip $ from cmd
+        if [ "$cmd" = "enddefinitions" ]; then # marks end of defs section of VCD
+            break
+        fi
+        if [[ "$cmd" == *"scope"* ]]; then # change of scope
+            if [ ${#waves[@]} -ne 0 ]; then # there are some waves to dump
+                echo "-$(join_with // ${hlevel[*]})" >> $gtkw_filename # comment: current hierarchy level
+                color=$(( (color%7)+1 )) # cycle colour
+                # dump waves
+                dn=""            # deferred wave name      } for building vectors
+                di=""            #          wave index     }  from bits
+                df=""            #          wave 1st index }
+                declare -a dw=() #          wave list      }
+                for w in ${waves[*]}; do # dump waves
+                    if [ ${w:0-1} = "]" ]; then # wave is vector (whole or bit)
+                        IFS='[' read -ra w_parts <<< "${w::-1}"
+                        n=${w_parts[0]} # name
+                        i=${w_parts[1]} # index
+                        if [[ "$i" == *":"* ]]; then # whole vector
+                            n=$w
+                            i=""
+                        fi
+                    else # scalar
+                        n=$w
+                        i=""
+                    fi
+                    if [ "$di" != "" ]; then # previous wave was vector bit
+                        if [ "$dn" != "$n" ]; then # this wave is not part of that vector
+                            # dump previous wave vector
+                            echo "#{$dn[$df:$di]} ${dw[*]}" >> $gtkw_filename
+                            dw=()
+                        else # this wave is part of that vector
+                            dw+=("$w")
+                        fi
+                    else # no previous wave to consider
+                        df=$i
+                        dw=()
+                    fi
+                    if [ "$i" = "" ]; then # this wave is not vector bit
+                        echo "[color] $color" >> $gtkw_filename
+                        echo "$w" >> $gtkw_filename
+                    fi
+                    dn=$n
+                    di=$i
+                done
+                if [ "$di" != "" ]; then # deal with final deferred wave
+                    echo "#{$dn[$df:$di]} ${dw[*]}" >> $gtkw_filename
+                    dw=()
+                fi
+                waves=() # reset wave list
+            fi
+        fi
+        if [ "$cmd" = "scope" ]; then
+            scope=${line_tokens[2]} # new scope name (descend hierarchy)
+            hlevel+=("$scope")
+        elif [ "$cmd" = "upscope" ]; then # ascend hierarchy
+            unset 'hlevel[$(( ${#hlevel[@]}-1 ))]' # pop last element
+            if [ ${#hlevel[@]} -ne 0 ]; then
+                scope=${hlevel[-1]}
+            else
+                scope=""
+            fi
+        elif [ "$cmd" = "var" ]; then
+            wave_name=${line_tokens[4]}
+            if [[ "${line_tokens[5]}" == "["*"]" ]]; then # bus wire - concatenate index
+                wave_name="$wave_name${line_tokens[5]}"
+            fi
+            # add signal if not too far down in hierarchy
+            if [ $levels -eq 0 ] || [ ${#hlevel[@]} le $levels]; then
+                waves+=("$(join_with . ${hlevel[*]}).$wave_name")
+            fi
+        fi
+    fi
+done <"$vcd_filename"


### PR DESCRIPTION
My make-support branch adds a handful of makefiles and a supporting shell script to the script directories of UVVM. These allow users trying UVVM for the first time to simulate the examples and view results as a waveform with a single make command. This depends on a correctly installed simulator (GHDL, NVC, ModelSim or Questa), and precompiled UVVM libraries. Windows users will need MSYS2 to run make. 

Here's a screenshot from my Windows PC:

![uvvm_make](https://user-images.githubusercontent.com/33783239/188807718-34d76173-ee4d-45ed-85d5-1b1c584c440d.png)
