### PR TITLE
Additional shell scripts

### DIFF
--- a/.github/workflows/test-ghdl.yml
+++ b/.github/workflows/test-ghdl.yml
@@ -1,0 +1,40 @@
+name: 'Test UVVM with GHDL'
+
+# TODO add events (push, pull_request, release) and/or schedule as required
+on: [workflow_dispatch]
+
+jobs:
+  test-ghdl:
+    name: 'Test UVVM with GHDL'
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: 'Setup MSYS2-MinGW64'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw32
+          update: true
+      - name: 'Install GHDL'
+        run: |
+          pacman -S --noconfirm mingw-w64-i686-ghdl-mcode
+      - name: 'Run Tests'
+        run: |
+          mkdir test && cd test
+          sh ../script/compile_all.sh ghdl
+          sh ../bitvis_irqc/script/compile_all_and_simulate.sh ghdl
+          grep -Rq "Simulation SUCCESS" ghdl/_Log.txt
+          if (( $? != 0 )); then
+            exit 1
+          fi
+          sh ../bitvis_uart/script/compile_all_and_simulate.sh ghdl
+          grep -Rq "Simulation SUCCESS" ghdl/_Log.txt
+          if (( $? != 0 )); then
+            exit 1
+          fi
+

--- a/.github/workflows/test-nvc.yml
+++ b/.github/workflows/test-nvc.yml
@@ -1,0 +1,44 @@
+name: 'Test UVVM with NVC'
+
+# TODO add events (push, pull_request, release) and/or schedule as required
+on: [workflow_dispatch]
+
+jobs:
+  test-nvc:
+    name: 'Test UVVM with NVC'
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: 'Setup MSYS2-MinGW64'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: true
+      - name: 'Install NVC'
+        run: |
+          : # temporary
+          wget https://www.nickg.me.uk/files/mingw-w64-x86_64-nvc-1.7.0.r209.g4ef679f1-1-any.pkg.tar.zst
+          pacman -U --noconfirm *.zst
+          : # TODO install from offical MSYS2 package when available
+          : # pacman -S --noconfirm mingw-w64-x86_64-nvc
+      - name: 'Run Tests'
+        run: |
+          mkdir test && cd test
+          sh ../script/compile_all.sh nvc
+          sh ../bitvis_irqc/script/compile_all_and_simulate.sh nvc
+          grep -Rq "Simulation SUCCESS" nvc/_Log.txt
+          if (( $? != 0 )); then
+            exit 1
+          fi
+          sh ../bitvis_uart/script/compile_all_and_simulate.sh nvc
+          grep -Rq "Simulation SUCCESS" nvc/_Log.txt
+          if (( $? != 0 )); then
+            exit 1
+          fi
+

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -11,19 +11,32 @@ A number of VHDL verification components (VVCs) are provided for free with this 
 NOTE: All Libraries, BFMs, VVCs, etc. have their own dedicated Quick Reference (QR) showing you all you need to use the respective part.
 
 ## Github directory naming notation
-- The directories starting with 'uvvm_' are the core libraries for UVVM Utility Library and UVVM VVC System
-- All directories starting with 'bitvis_vip_' are verification IP/modules from Bitvis
-- All other directories starting with 'bitvis_' are design IP/modules from Bitvis
+- The directories starting with `uvvm_` are the core libraries for UVVM Utility Library and UVVM VVC System
+- All directories starting with `bitvis_vip_` are verification IP/modules from Bitvis
+- All other directories starting with `bitvis_` are design IP/modules from Bitvis
 - Directories starting with 'x' are external (third party) libraries that work seamlessly with UVVM
 
-## List of demo testbenches
- - /bitvis_irqc/tb
-    - Navigate to /bitvis_irqc/sim
-    - Open "bitvis_irqc.mpf" or run "vsim -c -do ../script/compile_all_and_simulate.do"
+## Compiling all of UVVM
 
- - /bitvis_uart/tb
-    - Navigate to /bitvis_uart/sim
-    - Open "bitvis_uart.mpf" or run "vsim -c -do ../script/compile_all_and_simulate.do"
+The easiest way to compile the complete UVVM with everything (Utility Library, VVC Framework, BFMS, VVCs, etc.) is to go to the top-level script directory and either run `compile_all.do` inside Modelsim / Questasim / RivieraPro / ActiveHDL, or run the `compile_all.sh` shell script:
+
+    sh compile_all.sh <simulator> <target>
+
+`<simulator>` specifies the simulator to be used and should be `ghdl`, `nvc` or `vsim`. `<target_dir>` sets target directory (defaults to current directory if not specified).
+
+## Demo testbenches
+
+Demo testbenches are provided in the `bitvis_irqc` and `bitvis_uart` directories.
+
+To compile and simulate a demo, start by navigating to its `script` subdirectory. Users of ModelSim, Questa, Riviera Pro and ActiveHDl can run the `compile_all_and_simulate.do` script:
+
+     vsim -c -do compile_all_and_simulate.do
+
+Alternatively, run the `compile_all_and_simulate.sh` shell script:
+
+    sh compile_all_and_simulate.sh <simulator> <target_dir>
+
+`<simulator>` specifies the simulator to be used and should be `ghdl`, `nvc` or `vsim`. `<target_dir>` sets target directory (defaults to current directory if not specified).
 
 ## For developers with no previous UVVM experience:
 ### Step 1
@@ -32,23 +45,21 @@ You should start by first understanding and trying out the Utility Library. The 
 * Go through the powerpoint 'Making a simple, structured and efficient VHDL testbench – Step-by-step' linked to from the README-file
 
 ### Step 2
-To compile Utility Library related VHDL files you can do the following:
-* To compile Utility Library only you can use the following approaches:
-   * Running commands inside Modelsim/Questasim/RivieraPro/ActiveHDL:
-      1. Go to the uvvm_util/script directory using the simulator's console.
-      2. Run the command: do compile_src.do 
-         The following arguments are suported compile_src.do arg1 arg2 :
-         - arg1: sets source directory, target will be current directory if no arg2
-         - arg2: sets target directory
-   * Using GHDL:
-      Use GHDL provided script with uvvm_util/script/compile_order.txt as input
-   * Any other approach - or with script problems:
-      Follow compile order given in uvvm_util/script/compile_order.txt
-      Note that VHDL 2008 must be used. Lines starting with '# ' are required library definitions
-* To compile the complete IRQC demo testbench including Utility Library, SBI BFM and the IRQC DUT:
-   1. Use any of the approaches above and exchange the path 'uvvm_util' with 'bitvis_irqc'
-   2. Use the file compile_all_and_simulate.do instead.
-* To compile all above plus all provided BFMs, the scripts for compiling the complete UVVM should be used. (See below) (This compiles far more than you need, but then at least everything is pre-compiled)
+To compile Utility Library related VHDL files, navigate to `uvvm_util/script`. Users of Modelsim, Questasim, Riviera Pro or ActiveHDL may run the `compile_src.do` script in the simulator console:
+
+    do compile_src.do <source_dir> <target_dir>
+
+`<source_dir>` sets source directory, `<target_dir>` sets target directory (defaults to current directory if not specified).
+
+Alternatively, run the `compile_src.sh` shell script:
+
+    sh compile_src.sh <simulator> <target_dir>
+
+`<simulator>` specifies the simulator to be used and should be `ghdl`, `nvc` or `vsim`. `<target_dir>` sets target directory (defaults to current directory if not specified).
+
+To compile the demo testbenches, refer to the **Demo testbenches** section above.
+
+To compile everything, refer to the **Compiling all of UVVM** section above.
 
 ## For developers who understand the basics of UVVM Utility library and need more than just basic testbenches:
 ### Step 1
@@ -57,11 +68,17 @@ To compile Utility Library related VHDL files you can do the following:
 * For a slightly deeper introduction - also explaining the challenges - please check out our PPT-file [The_critically_missing_VHDL_TB_feature.ppsx](./uvvm_vvc_framework/doc/The_critically_missing_VHDL_TB_feature.ppsx)
 
 ### Step 2
-* The easiest way to compile the complete UVVM with everything (Utility Library, VVC Framework, BFMS, VVCs, etc.) is to go to the top-level script directory and run 'compile_all.do' inside Modelsim/Questasim/RivieraPro/ActiveHDL.
+* Refer to the **Compiling all of UVVM** section above.
 
-* For the UART VVC demo, go to bitvis_uart/script and run 'compile_all_and_simulate.do'
-
-* For GHDL use the provided 'compile_order.txt' files.
+* Refer to the **Demo testbenches** section above.
 
 ### Step 3
-If you like to use UVVM in a more advanced way you should read the relevant documentation under [UVVM VVC Framework doc](./uvvm_vvc_framework/doc)
+If you would like to use UVVM in a more advanced way you should read the relevant documentation under [UVVM VVC Framework doc](./uvvm_vvc_framework/doc).
+
+## Running Shell Scripts on Windows
+
+[MSYS2](https://www.msys2.org/) is recommended for running shell scripts, GNU utilities etc on Windows. It is also recommended for the GHDL and NVC simulators. Remember to add the MSYS2 binary directories to the Windows path if you would like to use a Windows Terminal or Command Prompt instead of the MSYS2 terminal:
+
+    C:\msys64\usr\bin
+    C:\msys64\mingw64\bin
+    C:\msys64\mingw32\bin

--- a/bitvis_irqc/README.TXT
+++ b/bitvis_irqc/README.TXT
@@ -3,8 +3,11 @@
 -----------------------------------------------------------
 
 Modelsim compile scripts are part of this release, see
-the script folder. For other simulators, see compile order
-in sim/compile_order.txt.
+the script folder. For other simulators, the compile order
+is provided in scripts/compile_order.txt. See also the
+following shell scripts:
+  compile_all_and_simulate.sh
+  ghdl_compile_all_and_simulate.sh
 
 -----------------------------------------------------------
 -- Directory structure                                   -- 
@@ -13,7 +16,5 @@ in sim/compile_order.txt.
 - bitvis_irqc     : An example Design Under Test (DUT) delivered with UVVM Utility Library in order to illustrate usage and debugging support provided by the library.
   - doc           : Documentation
   - script        : IRQC compile scripts
-  - sim           : Simulation directory. Simulation log files will be generated in this directory during simulation.  
   - src           : IRQC source code
   - tb            : IRQC Test bench
-

--- a/bitvis_irqc/script/.gitignore
+++ b/bitvis_irqc/script/.gitignore
@@ -1,0 +1,4 @@
+/nvc
+/ghdl
+/vsim
+/xsim

--- a/bitvis_irqc/script/compile_all_and_simulate.sh
+++ b/bitvis_irqc/script/compile_all_and_simulate.sh
@@ -1,0 +1,38 @@
+#!/bin/zsh
+
+# compile_all_and_simulate.sh
+# Compile all required sources and run simulation for bitvis_irqc demo.
+# Usage: sh compile_all_and_simulate.sh <simulator> <target_dir>
+# simulator  : ghdl, nvc, or vsim
+# target_dir : path to target directory (optional, defaults to .)
+
+set -o errexit
+SIM=$1
+TARGET_DIR=$2
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
+    SCRIPT_DIR=$(cygpath -m ${SCRIPT_DIR})
+fi
+UVVM_DIR=$SCRIPT_DIR/../..
+
+source $UVVM_DIR/script/multisim.sh
+
+# Compiling UVVM Util
+echo "Compiling UVVM Utility Library..."
+compile_component $UVVM_DIR/uvvm_util
+
+# Compiling Bitvis VIP SBI BFM
+echo "Compiling Bitvis VIP SBI BFM..."
+compile bitvis_vip_sbi $UVVM_DIR/bitvis_vip_sbi/src/sbi_bfm_pkg.vhd
+
+# Compiling Bitvis IRQC
+echo "Compiling Bitvis IRQC..."
+compile_component $UVVM_DIR/bitvis_irqc
+
+# Compiling demo TB
+echo "Compiling IRQC demo TB..."
+compile bitvis_irqc $UVVM_DIR/bitvis_irqc/tb/irqc_demo_tb.vhd
+
+# Running simulations
+echo "Starting simulations..."
+simulate bitvis_irqc irqc_demo_tb

--- a/bitvis_uart/README.TXT
+++ b/bitvis_uart/README.TXT
@@ -7,8 +7,11 @@ This is just a simple test vehicle that can be used to
 demonstrate the functionality of the UVVM VVC Framework.
 
 Modelsim compile scripts are part of this release, see
-the script folder. For other simulators, see compile order
-in sim/compile_order.txt.
+the script folder. For other simulators, the compile order
+is provided in scripts/compile_order.txt. See also the
+following shell scripts:
+  compile_all_and_simulate.sh
+  ghdl_compile_all_and_simulate.sh
 
 -----------------------------------------------------------
 -- Directory structure                                   -- 
@@ -17,7 +20,5 @@ in sim/compile_order.txt.
 - bitvis_uart     : An example Design Under Test (DUT) delivered with UVVM in order to illustrate usage and debugging support provided by the library.
   - doc           : Documentation
   - script        : UART compile scripts
-  - sim           : Simulation directory with a Modelsim project file. Simulation log files will be generated in this directory during simulation.  
   - src           : UART source code
   - tb            : UART Test bench
-

--- a/bitvis_uart/script/.gitignore
+++ b/bitvis_uart/script/.gitignore
@@ -1,0 +1,4 @@
+/nvc
+/ghdl
+/vsim
+/xsim

--- a/bitvis_uart/script/compile_all_and_simulate.sh
+++ b/bitvis_uart/script/compile_all_and_simulate.sh
@@ -1,0 +1,55 @@
+#!/bin/zsh
+
+# compile_all_and_simulate.sh
+# Compile all required sources and run simulation for bitvis_uart demo.
+# Usage: sh compile_all_and_simulate.sh <simulator> <target_dir>
+# simulator  : ghdl, nvc, or vsim
+# target_dir : path to target directory (optional, defaults to .)
+
+set -o errexit
+SIM=$1
+TARGET_DIR=$2
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
+    SCRIPT_DIR=$(cygpath -m ${SCRIPT_DIR})
+fi
+UVVM_DIR=$SCRIPT_DIR/../..
+
+source $UVVM_DIR/script/multisim.sh
+
+# Compiling UVVM Util
+echo "Compiling UVVM Utility Library..."
+compile_component $UVVM_DIR/uvvm_util
+
+# Compiling UVVM VVC Framework
+echo "Compiling UVVM VVC Framework..."
+compile_component $UVVM_DIR/uvvm_vvc_framework
+
+# Compiling Bitvis VIP Scoreboard
+echo "Compiling Bitvis VIP Scoreboard..."
+compile_component $UVVM_DIR/bitvis_vip_scoreboard
+
+# Compiling Bitvis VIP SBI
+echo "Compiling Bitvis VIP SBI..."
+compile_component $UVVM_DIR/bitvis_vip_sbi
+
+# Compiling Bitvis VIP UART
+echo "Compiling Bitvis VIP UART..."
+compile_component $UVVM_DIR/bitvis_vip_uart
+
+# Compiling Bitvis VIP Clock Generator
+echo "Compiling Bitvis VIP Clock Generator..."
+compile_component $UVVM_DIR/bitvis_vip_clock_generator
+
+# Compiling Bitvis UART
+echo "Compiling Bitvis UART..."
+compile_component $UVVM_DIR/bitvis_uart
+
+# Compiling UART VVC demo TB
+echo "Compiling UART VVC demo TB..."
+compile bitvis_uart $UVVM_DIR/bitvis_uart/tb/uart_vvc_demo_th.vhd
+compile bitvis_uart $UVVM_DIR/bitvis_uart/tb/uart_vvc_demo_tb.vhd
+
+# Running simulations
+echo "Starting simulations..."
+simulate bitvis_uart uart_vvc_demo_tb

--- a/script/.gitignore
+++ b/script/.gitignore
@@ -1,0 +1,4 @@
+/nvc
+/ghdl
+/vsim
+/xsim

--- a/script/compile_all.sh
+++ b/script/compile_all.sh
@@ -1,0 +1,23 @@
+#!/bin/zsh
+
+# compile_all.sh
+# Compiles all UVVM libraries and VIPs.
+# Usage: sh compile_all.sh <simulator> <target_dir>
+# simulator  : ghdl, nvc, or vsim
+# target_dir : path to target directory (optional, defaults to .)
+
+set -o errexit
+SIM=$1
+TARGET_DIR=$2
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
+    SCRIPT_DIR=$(cygpath -m ${SCRIPT_DIR})
+fi
+UVVM_DIR=$SCRIPT_DIR/..
+
+source $UVVM_DIR/script/multisim.sh
+
+component_list=$(tr -d '\r' <$UVVM_DIR/script/component_list.txt | tr '\n' ' ')
+for component in $component_list; do
+    compile_component $UVVM_DIR/$component
+done

--- a/script/multisim.sh
+++ b/script/multisim.sh
@@ -1,0 +1,84 @@
+# multisim.sh
+# Simple support for driving UVVM from shell scripts.
+# Supported simulators: GHDL, NVC, ModelSim/Questa, Xilinx Vivado (XSim).
+# For examples of use, see compile_all.sh in this directory, and the
+# compile_all_and_simulate.sh scripts for bitvis_uart and bitvis_irqc.
+
+set -o errexit
+
+if [ -z $SIM ]; then
+    echo "no simulator specified"
+    echo "supported simulators: ghdl, nvc, vsim, xsim"
+    exit 1
+fi
+if [ -z $TARGET_DIR ]; then
+    TARGET_DIR="."
+fi
+
+abspath () {
+    _paths=("$@")
+    if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
+        echo "$(cygpath -m $(realpath ${_paths[@]}))"
+    else
+        echo "$(realpath ${_paths[@]})"
+    fi
+}
+
+# compile one or more sources into specified library
+# arguments:
+# $1 = library
+# $2..$n = VHDL source files
+compile () {
+    _lib=$1 && shift && _sources=($(abspath "$@"))
+    if [ "$SIM" = "ghdl" ]; then
+        cmd="ghdl -a --work=${_lib} --std=08 -frelaxed -fsynopsys -Wno-hide -Wno-shared ${_sources[@]}"
+    elif [ "$SIM" = "nvc" ]; then
+        cmd="nvc --std=2008 -L . --work=${_lib} -a --relaxed ${_sources[@]}"
+    elif [ "$SIM" = "vsim" ]; then
+        cmd="vcom -2008 -work ${_lib} -explicit -vopt -stats=none ${_sources[@]}"
+    elif [ "$SIM" = "xsim" ]; then
+        cmd="xvhdl -2008 -work ${_lib} ${_sources[@]}"
+    else
+        echo "unsupported simulator (${SIM})"
+        echo "supported simulators: ghdl, nvc, vsim, xsim"
+        exit 1
+    fi
+    _dir=$(abspath $TARGET_DIR/$SIM)
+    ( mkdir -p $_dir && cd $_dir && echo "${cmd}" && bash -c "$cmd" )
+}
+
+# compile sources for specified UVVM component, using its compile_order.txt file
+# arguments:
+# $1 = component directory
+compile_component () {
+    _path=$(abspath $1) && _component=$(basename $_path)
+    _compile_order=($(tail -n +2 "$_path/script/compile_order.txt" | tr -d '\r' | tr '\n' ' '))
+    _sources=()
+    for _source in "${_compile_order[@]}"; do
+        _sources+=("${_path}/script/${_source}")
+    done    
+    compile $_component ${_sources[@]}
+}
+
+# run simulation
+# arguments:
+# $1 = library
+# $2 = design unit
+simulate () {
+    _lib=$1 && _top=$2
+    if [ "$SIM" = "ghdl" ]; then
+        cmd="ghdl --elab-run --work=${_lib} --std=08 -frelaxed -fsynopsys ${_top}"
+    elif [ "$SIM" = "nvc" ]; then
+        cmd="nvc --std=2008 -L . --work=${_lib} -e ${_top} && nvc --std=2008 -L . --work=${_lib} -r ${_top}"        
+    elif [ "$SIM" = "vsim" ]; then
+        cmd="vsim -work ${_lib} -t ps -c -onfinish stop -do \"onfinish exit; run -all; exit\" ${_top}"
+    elif [ "$SIM" = "xsim" ]; then
+        cmd="xelab --relax -top ${_lib}.${_top} -snapshot ${_top}_snapshot && xsim -runall --onerror quit --onfinish quit ${_top}_snapshot"
+    else
+        echo "unsupported simulator (${SIM})"
+        echo "supported simulators: ghdl, nvc, vsim, xsim"
+        exit 1
+    fi
+    _dir=$(abspath $TARGET_DIR/$SIM)
+    ( mkdir -p $_dir && cd $_dir && echo "${cmd}" && bash -c "$cmd" )
+}

--- a/uvvm_util/script/.gitignore
+++ b/uvvm_util/script/.gitignore
@@ -1,0 +1,4 @@
+/nvc
+/ghdl
+/vsim
+/xsim

--- a/uvvm_util/script/compile_src.sh
+++ b/uvvm_util/script/compile_src.sh
@@ -1,0 +1,20 @@
+#!/bin/zsh
+
+# compile_src.sh
+# Compiles UVVM component (library or VIP).
+# Usage: sh compile_src.sh <simulator> <source_dir> <target_dir>
+# simulator   : ghdl, nvc, or vsim
+# target_dir  : path to target directory (optional, defaults to .)
+
+set -o errexit
+SIM=$1
+TARGET_DIR=$2
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
+    SCRIPT_DIR=$(cygpath -m ${SCRIPT_DIR})
+fi
+UVVM_DIR=$SCRIPT_DIR/../..
+
+source $UVVM_DIR/script/multisim.sh
+
+compile_component $SCRIPT_DIR/..


### PR DESCRIPTION
Shell scripts to improve the "first contact" experience with UVVM. Associated documentation updates and .gitignore files.

A first time user can now navigate to the script subdirectory of a demo and run a shell script to compile and simulate the demo with GHDL, NVC or ModelSim etc. The script also supports Xilinx XSim but of (as of version 2022.2) this still does not support VHDL-2008 well enough.