### PR TITLE
Bug: Generic GC_CMD_QUEUE_COUNT_MAX in AXI VVC does not update sizes of command queues

### DIFF
--- a/bitvis_vip_axi/src/axi_vvc.vhd
+++ b/bitvis_vip_axi/src/axi_vvc.vhd
@@ -450,7 +450,7 @@ begin
         uvvm_vvc_framework.ti_vvc_framework_support_pkg.reset_flag(terminate_current_cmd);
       end if;
 
-      -- In case we only allow a single pending transaction, wait here until every channel is finished. 
+      -- In case we only allow a single pending transaction, wait here until every channel is finished.
       -- Even though this wait doesn't have a timeout, each of the executors have timeouts.
       if vvc_config.force_single_pending_transaction and v_command_is_bfm_access then
         wait until not write_address_channel_executor_is_busy and not write_data_channel_executor_is_busy and not write_response_channel_executor_is_busy and not read_address_channel_executor_is_busy and not read_data_channel_executor_is_busy;
@@ -472,6 +472,7 @@ begin
     constant C_CHANNEL_SCOPE      : string                                     := C_VVC_NAME & "_AR" & "," & to_string(GC_INSTANCE_IDX);
     constant C_CHANNEL_VVC_LABELS : t_vvc_labels                               := assign_vvc_labels(C_CHANNEL_SCOPE, C_VVC_NAME, GC_INSTANCE_IDX, NA);
   begin
+    wait for 0 ns;                      -- delay by 1 delta cycle to allow constructor to finish first
     -- Set the command response queue up to the same settings as the command queue
     read_address_channel_queue.set_scope(C_CHANNEL_SCOPE & ":Q");
     read_address_channel_queue.set_queue_count_max(vvc_config.cmd_queue_count_max);
@@ -549,6 +550,7 @@ begin
     constant C_CHANNEL_SCOPE        : string       := C_VVC_NAME & "_R" & "," & to_string(GC_INSTANCE_IDX);
     constant C_CHANNEL_VVC_LABELS   : t_vvc_labels := assign_vvc_labels(C_CHANNEL_SCOPE, C_VVC_NAME, GC_INSTANCE_IDX, NA);
   begin
+    wait for 0 ns;                      -- delay by 1 delta cycle to allow constructor to finish first
     -- Set the command response queue up to the same settings as the command queue
     read_data_channel_queue.set_scope(C_CHANNEL_SCOPE & ":Q");
     read_data_channel_queue.set_queue_count_max(vvc_config.cmd_queue_count_max);
@@ -705,6 +707,7 @@ begin
     constant C_CHANNEL_SCOPE      : string                                     := C_VVC_NAME & "_AW" & "," & to_string(GC_INSTANCE_IDX);
     constant C_CHANNEL_VVC_LABELS : t_vvc_labels                               := assign_vvc_labels(C_CHANNEL_SCOPE, C_VVC_NAME, GC_INSTANCE_IDX, NA);
   begin
+    wait for 0 ns;                      -- delay by 1 delta cycle to allow constructor to finish first
     -- Set the command response queue up to the same settings as the command queue
     write_address_channel_queue.set_scope(C_CHANNEL_SCOPE & ":Q");
     write_address_channel_queue.set_queue_count_max(vvc_config.cmd_queue_count_max);
@@ -778,6 +781,7 @@ begin
     constant C_CHANNEL_SCOPE      : string       := C_VVC_NAME & "_W" & "," & to_string(GC_INSTANCE_IDX);
     constant C_CHANNEL_VVC_LABELS : t_vvc_labels := assign_vvc_labels(C_CHANNEL_SCOPE, C_VVC_NAME, GC_INSTANCE_IDX, NA);
   begin
+    wait for 0 ns;                      -- delay by 1 delta cycle to allow constructor to finish first
     -- Set the command response queue up to the same settings as the command queue
     write_data_channel_queue.set_scope(C_CHANNEL_SCOPE & ":Q");
     write_data_channel_queue.set_queue_count_max(vvc_config.cmd_queue_count_max);
@@ -848,6 +852,7 @@ begin
     constant C_CHANNEL_SCOPE        : string       := C_VVC_NAME & "_B" & "," & to_string(GC_INSTANCE_IDX);
     constant C_CHANNEL_VVC_LABELS   : t_vvc_labels := assign_vvc_labels(C_CHANNEL_SCOPE, C_VVC_NAME, GC_INSTANCE_IDX, NA);
   begin
+    wait for 0 ns;                      -- delay by 1 delta cycle to allow constructor to finish first
     -- Set the command response queue up to the same settings as the command queue
     write_response_channel_queue.set_scope(C_CHANNEL_SCOPE & ":Q");
     write_response_channel_queue.set_queue_count_max(vvc_config.cmd_queue_count_max);

--- a/bitvis_vip_axi/src/axi_vvc.vhd
+++ b/bitvis_vip_axi/src/axi_vvc.vhd
@@ -450,7 +450,7 @@ begin
         uvvm_vvc_framework.ti_vvc_framework_support_pkg.reset_flag(terminate_current_cmd);
       end if;
 
-      -- In case we only allow a single pending transaction, wait here until every channel is finished.
+      -- In case we only allow a single pending transaction, wait here until every channel is finished. 
       -- Even though this wait doesn't have a timeout, each of the executors have timeouts.
       if vvc_config.force_single_pending_transaction and v_command_is_bfm_access then
         wait until not write_address_channel_executor_is_busy and not write_data_channel_executor_is_busy and not write_response_channel_executor_is_busy and not read_address_channel_executor_is_busy and not read_data_channel_executor_is_busy;


### PR DESCRIPTION
Run the following minimal example simulation after having compiled UVVM and VVCs from the latest release: https://gist.github.com/am9417/9a24f9b84b32fa780ee4387f95342aba#file-axi_vvc_tb-vhd

The simulation configures an AXI VVC instance where the command queue (and the result queue) has a size of 1000 elements and a warning threshold at 950 elements. Then, 1000 write commands are added into the command queue simultaneously by issuing an `axi_write` commands, and the simulation finishes after a nanosecond. I would assume that the simulation would pass with only a warning raised after there are 950 elements in the queue.

However, the following TB_ERROR is raised, and the test won't pass:
> 'add() into generic queue (of size 150) when full'

which does not make sense as the queues should have the capacity for a thousand elements.

Looking at [bitvis_vip_axi/src/axi_vvc.vhd:178](https://github.com/UVVM/UVVM/blob/master/bitvis_vip_axi/src/axi_vvc.vhd#L178), the command and result queues are set up with a parallel `vvc_constructor` procedure from `td_vvc_entity_support_pkg` and queue size and threshold parameters from the generics are passed there. The constructor procedure in [uvvm_vvc_framework/src_target_dependent/td_vvc_entity_support_pkg.vhd:354](https://github.com/UVVM/UVVM/blob/master/uvvm_vvc_framework/src_target_dependent/td_vvc_entity_support_pkg.vhd#L354) also updates the shared `vvc_config` variable with the desired queue size.

All five AXI channels seem to have individual command queues (or "channel queues") as well as separate executor processes where the actual VVC commands are multiplexed and executed. The command queues are initialized at the start of the executor processes with the queue size in the shared variable `vvc_config`.

However, the value in the shared variable is not yet updated from the generic `GC_CMD_QUEUE_COUNT_MAX` because the vvc_constructor is still running at the same time. So the channel queues get initialised with the default command queue size instead (defined in `C_CMD_QUEUE_COUNT_MAX` in adaptations_pkg.vhd, 150 for me).

The queues should be initialised with the same size as the command queue, as stated in the comment in the executor processes: `-- Set the command response queue up to the same settings as the command queue`. So, adding 0 ns delays to get the vvc_constructor finished before reading the queue sizes from vvc_config in channel executor processes. The testbench in the example passes.