### PR TITLE
Fix for updating v_num_data_bits when configuration changes

### DIFF
--- a/bitvis_vip_uart/src/uart_bfm_pkg.vhd
+++ b/bitvis_vip_uart/src/uart_bfm_pkg.vhd
@@ -152,7 +152,7 @@ package uart_bfm_pkg is
   -- - If the number of '1' in the 'data' input is odd, '1' will be returned
   -- - If the number of '1' in the 'data' input is even, '0' will be returned
   function odd_parity(
-    constant data : std_logic_vector(7 downto 0))
+    constant data : std_logic_vector)
   return std_logic;
 
 end package uart_bfm_pkg;
@@ -163,7 +163,7 @@ end package uart_bfm_pkg;
 package body uart_bfm_pkg is
 
   function odd_parity(
-    constant data : std_logic_vector(7 downto 0))
+    constant data : std_logic_vector)
   return std_logic is
   begin
     return xnor(data);

--- a/bitvis_vip_uart/src/uart_rx_vvc.vhd
+++ b/bitvis_vip_uart/src/uart_rx_vvc.vhd
@@ -249,6 +249,8 @@ begin
       -- update vvc activity
       update_vvc_activity_register(global_trigger_vvc_activity_register, vvc_status, ACTIVE, entry_num_in_vvc_activity_register, last_cmd_idx_executed, command_queue.is_empty(VOID), C_SCOPE);
 
+      v_num_data_bits := vvc_config.bfm_config.num_data_bits;
+
       -- Set the transaction info for waveview
       transaction_info           := C_TRANSACTION_INFO_DEFAULT;
       transaction_info.operation := v_cmd.operation;

--- a/bitvis_vip_uart/src/uart_tx_vvc.vhd
+++ b/bitvis_vip_uart/src/uart_tx_vvc.vhd
@@ -242,6 +242,8 @@ begin
       -- update vvc activity
       update_vvc_activity_register(global_trigger_vvc_activity_register, vvc_status, ACTIVE, entry_num_in_vvc_activity_register, last_cmd_idx_executed, command_queue.is_empty(VOID), C_SCOPE);
 
+      v_num_data_bits := vvc_config.bfm_config.num_data_bits;
+
       -- Set the transaction info for waveview
       transaction_info           := C_TRANSACTION_INFO_DEFAULT;
       transaction_info.operation := v_cmd.operation;


### PR DESCRIPTION
The value of the **v_num_data_bits** variable is not updated when the configuration of the VIP UART instance is changed.
This is already solved in **UVVM_3_BETA**. However, it would be good to integrate this fix into the UVVM as well.
Also removed the constraint from the parameter in the **odd_parity()** function to support different data widths.

BR