### PR TITLE
Removed unnecessary use clause in vvc_methods_pkg.vhd for the UART VVC

### DIFF
--- a/bitvis_vip_uart/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_uart/src/vvc_methods_pkg.vhd
@@ -26,7 +26,6 @@ use uvvm_vvc_framework.ti_vvc_framework_support_pkg.all;
 
 use work.uart_bfm_pkg.all;
 use work.vvc_cmd_pkg.all;
-use work.monitor_cmd_pkg.all;
 use work.td_target_support_pkg.all;
 use work.transaction_pkg.all;
 use work.vvc_sb_pkg.all;


### PR DESCRIPTION
Removed unnecessary use clause causing the documentation to not be correct

Closes #256 