### PR TITLE
Fixed unwanted messages from VVCs

### DIFF
--- a/bitvis_vip_axi/src/axi_vvc.vhd
+++ b/bitvis_vip_axi/src/axi_vvc.vhd
@@ -600,7 +600,7 @@ begin
             for i in 1 to v_queue_count loop
               v_cmd            := read_data_channel_queue.peek(POSITION, i);
               v_normalized_rid := normalize_and_check(v_cmd.id, v_normalized_rid, ALLOW_WIDER_NARROWER, "v_cmd.id", "v_normalized_rid", v_cmd.msg);
-              if check_value(v_result.rid, v_normalized_rid, vvc_config.bfm_config.match_strictness, NO_ALERT, "Checking if the correct ID is found in the command queue", C_CHANNEL_SCOPE) then
+              if check_value(v_result.rid, v_normalized_rid, vvc_config.bfm_config.match_strictness, NO_ALERT, "Checking if the correct ID is found in the command queue", C_CHANNEL_SCOPE, HEX_BIN_IF_INVALID, KEEP_LEADING_0, ID_NEVER, v_msg_id_panel) then
                 -- Correct ID found. We stop searching for the ID
                 read_data_channel_queue.delete(POSITION, i, SINGLE);
                 exit;
@@ -654,7 +654,7 @@ begin
             for i in 1 to v_queue_count loop
               v_cmd            := read_data_channel_queue.peek(POSITION, i);
               v_normalized_rid := normalize_and_check(v_cmd.id, v_normalized_rid, ALLOW_WIDER_NARROWER, "v_cmd.id", "v_normalized_rid", v_cmd.msg);
-              if check_value(v_result.rid, v_normalized_rid, vvc_config.bfm_config.match_strictness, NO_ALERT, "Checking if the correct ID is found in the command queue", C_CHANNEL_SCOPE) then
+              if check_value(v_result.rid, v_normalized_rid, vvc_config.bfm_config.match_strictness, NO_ALERT, "Checking if the correct ID is found in the command queue", C_CHANNEL_SCOPE, HEX_BIN_IF_INVALID, KEEP_LEADING_0, ID_NEVER, v_msg_id_panel) then
                 -- Correct ID found. We stop searching for the ID
                 read_data_channel_queue.delete(POSITION, i, SINGLE);
                 exit;
@@ -925,7 +925,7 @@ begin
         for i in 1 to v_queue_count loop
           v_cmd            := write_response_channel_queue.peek(POSITION, i);
           v_normalized_bid := normalize_and_check(v_cmd.id, v_normalized_bid, ALLOW_WIDER_NARROWER, "v_cmd.id", "v_normalized_bid", v_cmd.msg);
-          if check_value(v_bid_value, v_normalized_bid, vvc_config.bfm_config.match_strictness, NO_ALERT, "Checking if the correct ID is found in the command queue", C_CHANNEL_SCOPE) then
+          if check_value(v_bid_value, v_normalized_bid, vvc_config.bfm_config.match_strictness, NO_ALERT, "Checking if the correct ID is found in the command queue", C_CHANNEL_SCOPE, HEX_BIN_IF_INVALID, KEEP_LEADING_0, ID_NEVER, v_msg_id_panel) then
             -- Correct ID found. We stop searching for the ID
             write_response_channel_queue.delete(POSITION, i, SINGLE);
             exit;

--- a/bitvis_vip_axilite/src/axilite_channel_handler_pkg.vhd
+++ b/bitvis_vip_axilite/src/axilite_channel_handler_pkg.vhd
@@ -457,7 +457,7 @@ package body axilite_channel_handler_pkg is
     -- Checking RDATA
     for i in v_normalized_data'range loop
       -- Allow don't care in expected value and use match strictness from config for comparison
-      if v_normalized_data(i) = '-' or check_value(v_rdata_value(i), v_normalized_data(i), config.match_strictness, NO_ALERT, msg) then
+      if v_normalized_data(i) = '-' or check_value(v_rdata_value(i), v_normalized_data(i), config.match_strictness, NO_ALERT, msg, scope, ID_NEVER, msg_id_panel) then
         v_rdata_ok := true;
       else
         v_rdata_ok := false;
@@ -468,7 +468,7 @@ package body axilite_channel_handler_pkg is
     if not v_rdata_ok then
       -- Use binary representation when mismatch is due to weak signals
       if not v_rdata_ok then
-        v_alert_radix := BIN when config.match_strictness = MATCH_EXACT and check_value(v_rdata_value, v_normalized_data, MATCH_STD, NO_ALERT, msg) else HEX;
+        v_alert_radix := BIN when config.match_strictness = MATCH_EXACT and check_value(v_rdata_value, v_normalized_data, MATCH_STD, NO_ALERT, msg, scope, HEX_BIN_IF_INVALID, KEEP_LEADING_0, ID_NEVER, msg_id_panel) else HEX;
         alert(alert_level, proc_call & "=> Failed. Was " & to_string(v_rdata_value, v_alert_radix, AS_IS, INCL_RADIX) & ". Expected " & to_string(v_normalized_data, v_alert_radix, AS_IS, INCL_RADIX) & "." & LF & add_msg_delimiter(msg), scope);
       end if;
     else

--- a/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
+++ b/bitvis_vip_axistream/src/axistream_bfm_pkg.vhd
@@ -888,7 +888,7 @@ package body axistream_bfm_pkg is
     deprecate(C_PROC_NAME, "data_array as t_byte_array has been deprecated. Use data_array as t_slv_array.");
 
     -- t_byte_array sanity check
-    v_check_ok := check_value(data_array'length > 0, TB_ERROR, C_PROC_CALL & "data_array length must be > 0", "VVC");
+    v_check_ok := check_value(data_array'length > 0, TB_ERROR, C_PROC_CALL & "data_array length must be > 0", scope, ID_NEVER, msg_id_panel);
     if v_check_ok then
       -- call t_slv_array overloaded procedure
       axistream_transmit(data_array, user_array, strb_array, id_array, dest_array, msg, clk, axistream_if, scope, msg_id_panel, config);
@@ -1937,7 +1937,7 @@ package body axistream_bfm_pkg is
 
   begin
     -- t_byte_array sanity check
-    v_check_ok := check_value(exp_data_array'length > 0, TB_ERROR, C_PROC_CALL & "data_array length must be > 0", "VVC");
+    v_check_ok := check_value(exp_data_array'length > 0, TB_ERROR, C_PROC_CALL & "data_array length must be > 0", scope, ID_NEVER, msg_id_panel);
 
     if v_check_ok then
       -- call t_byte_array overloaded procedure

--- a/bitvis_vip_axistream/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_axistream/src/vvc_methods_pkg.vhd
@@ -879,7 +879,7 @@ package body vvc_methods_pkg is
     deprecate(C_PROC_NAME, "data_array as t_byte_array has been deprecated. Use data_array as t_slv_array.");
     
     -- t_byte_array sanity check
-    v_check_ok := check_value(data_array'length > 0, TB_ERROR, C_PROC_CALL & "data_array length must be > 0", "VVC");
+    v_check_ok := check_value(data_array'length > 0, TB_ERROR, C_PROC_CALL & "data_array length must be > 0", scope, ID_NEVER, parent_msg_id_panel);
     if v_check_ok then
       -- Call t_slv_array overloaded procedure
       axistream_expect(VVCT, vvc_instance_idx, data_array, user_array, strb_array, id_array, dest_array, msg, alert_level, scope, parent_msg_id_panel);

--- a/bitvis_vip_scoreboard/src/generic_sb_support_pkg.vhd
+++ b/bitvis_vip_scoreboard/src/generic_sb_support_pkg.vhd
@@ -58,7 +58,7 @@ package body generic_sb_support_pkg is
   ) return std_logic_vector is
     variable v_padded_slv : std_logic_vector(pad_width - 1 downto 0) := (others => '0');
   begin
-    check_value(pad_data'length <= pad_width, TB_WARNING, "check: pad_data width exceed pad_width");
+    check_value(pad_data'length <= pad_width, TB_WARNING, "check: pad_data width exceed pad_width", C_VVC_CMD_SCOPE_DEFAULT, ID_NEVER);
 
     v_padded_slv(pad_data'length - 1 downto 0) := pad_data;
     return v_padded_slv;

--- a/bitvis_vip_wishbone/src/wishbone_bfm_pkg.vhd
+++ b/bitvis_vip_wishbone/src/wishbone_bfm_pkg.vhd
@@ -178,7 +178,7 @@ package body wishbone_bfm_pkg is
 
     -- check if enough room for setup_time in low period
     if (clk = '1') and (config.setup_time > (config.clock_period / 2 - clk'last_event)) then
-      await_value(clk, '0', 0 ns, config.clock_period / 2, TB_FAILURE, proc_name & ": timeout waiting for clk low period for setup_time.");
+      await_value(clk, '0', 0 ns, config.clock_period / 2, TB_FAILURE, proc_name & ": timeout waiting for clk low period for setup_time.", scope, ID_NEVER, msg_id_panel);
     end if;
     -- Wait setup_time specified in config record  --wait_until_given_time_after_rising_edge(clk, config.clock_period/4);
     wait_until_given_time_after_rising_edge(clk, config.setup_time);
@@ -192,7 +192,7 @@ package body wishbone_bfm_pkg is
     wait until falling_edge(clk);       -- wait for DUT update of signal
     -- check if clk period since last rising edge is within specifications and take a new time stamp
     if v_last_falling_edge > -1 ns then
-      check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.");
+      check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.", scope, ID_NEVER, msg_id_panel);
     end if;
     v_last_falling_edge := now;         -- time stamp for clk period checking
 
@@ -201,7 +201,7 @@ package body wishbone_bfm_pkg is
         wait until falling_edge(clk);
         -- check if clk period since last rising edge is within specifications and take a new time stamp
         if v_last_falling_edge > -1 ns then
-          check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.");
+          check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.", scope, ID_NEVER, msg_id_panel);
         end if;
         v_last_falling_edge := now;     -- time stamp for clk period checking
       else
@@ -267,7 +267,7 @@ package body wishbone_bfm_pkg is
 
     -- check if enough room for setup_time in low period
     if (clk = '1') and (config.setup_time > (config.clock_period / 2 - clk'last_event)) then
-      await_value(clk, '0', 0 ns, config.clock_period / 2, TB_FAILURE, local_proc_name & ": timeout waiting for clk low period for setup_time.");
+      await_value(clk, '0', 0 ns, config.clock_period / 2, TB_FAILURE, local_proc_name & ": timeout waiting for clk low period for setup_time.", scope, ID_NEVER, msg_id_panel);
     end if;
     -- Wait setup_time specified in config record -- wait_until_given_time_after_rising_edge(clk, config.clock_period/4);
     wait_until_given_time_after_rising_edge(clk, config.setup_time);
@@ -280,7 +280,7 @@ package body wishbone_bfm_pkg is
     wait until falling_edge(clk);       -- wait for DUT update of signal
     -- check if clk period since last rising edge is within specifications and take a new time stamp
     if v_last_falling_edge > -1 ns then
-      check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.");
+      check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.", scope, ID_NEVER, msg_id_panel);
     end if;
     v_last_falling_edge := now;         -- time stamp for clk period checking
 
@@ -289,7 +289,7 @@ package body wishbone_bfm_pkg is
         wait until falling_edge(clk);
         -- check if clk period since last rising edge is within specifications and take a new time stamp
         if v_last_falling_edge > -1 ns then
-          check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.");
+          check_value_in_range(now - v_last_falling_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.", scope, ID_NEVER, msg_id_panel);
         end if;
         v_last_falling_edge := now;     -- time stamp for clk period checking
       else
@@ -307,7 +307,7 @@ package body wishbone_bfm_pkg is
       wait until rising_edge(clk);
       -- check if clk period since last rising edge is within specifications and take a new time stamp
       if v_last_rising_edge > -1 ns then
-        check_value_in_range(now - v_last_rising_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.");
+        check_value_in_range(now - v_last_rising_edge, config.clock_period - config.clock_period_margin, config.clock_period + config.clock_period_margin, config.clock_margin_severity, "checking clk period is within requirement.", scope, ID_NEVER, msg_id_panel);
       end if;
       v_last_rising_edge := now;        -- time stamp for clk period checking
 
@@ -353,7 +353,7 @@ package body wishbone_bfm_pkg is
 
     for i in v_normalized_data'range loop
       -- Allow don't care in expected value and use match strictness from config for comparison
-      if v_normalized_data(i) = '-' or check_value(v_data_value(i), v_normalized_data(i), config.match_strictness, NO_ALERT, msg) then
+      if v_normalized_data(i) = '-' or check_value(v_data_value(i), v_normalized_data(i), config.match_strictness, NO_ALERT, msg, scope, ID_NEVER, msg_id_panel) then
         v_check_ok := true;
       else
         v_check_ok := false;
@@ -363,7 +363,7 @@ package body wishbone_bfm_pkg is
 
     if not v_check_ok then
       -- Use binary representation when mismatch is due to weak signals
-      v_alert_radix := BIN when config.match_strictness = MATCH_EXACT and check_value(v_data_value, v_normalized_data, MATCH_STD, NO_ALERT, msg) else HEX;
+      v_alert_radix := BIN when config.match_strictness = MATCH_EXACT and check_value(v_data_value, v_normalized_data, MATCH_STD, NO_ALERT, msg, scope, HEX_BIN_IF_INVALID, KEEP_LEADING_0, ID_NEVER, msg_id_panel) else HEX;
       alert(alert_level, proc_call & "=> Failed. Was " & to_string(v_data_value, v_alert_radix, AS_IS, INCL_RADIX) & ". Expected " & to_string(v_normalized_data, v_alert_radix, AS_IS, INCL_RADIX) & "." & LF & add_msg_delimiter(msg), scope);
     else
       log(config.id_for_bfm, proc_call & "=> OK, received data = " & to_string(v_normalized_data, HEX, SKIP_LEADING_0, INCL_RADIX) & ". " & add_msg_delimiter(msg), scope, msg_id_panel);

--- a/uvvm_util/src/methods_pkg.vhd
+++ b/uvvm_util/src/methods_pkg.vhd
@@ -5024,8 +5024,8 @@ package body methods_pkg is
   begin
     protected_check_counters.increment(CHECK_VALUE);
 
-    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope);
-    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope);
+    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope, ID_NEVER, msg_id_panel);
+    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope, ID_NEVER, msg_id_panel);
 
     if v_len_check_ok and v_dir_check_ok then
       for idx in exp'range loop
@@ -5082,8 +5082,8 @@ package body methods_pkg is
   begin
     protected_check_counters.increment(CHECK_VALUE);
 
-    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope);
-    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope);
+    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope, ID_NEVER, msg_id_panel);
+    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope, ID_NEVER, msg_id_panel);
 
     if v_len_check_ok and v_dir_check_ok then
       for idx in exp'range loop
@@ -5140,8 +5140,8 @@ package body methods_pkg is
   begin
     protected_check_counters.increment(CHECK_VALUE);
 
-    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope);
-    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope);
+    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope, ID_NEVER, msg_id_panel);
+    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope, ID_NEVER, msg_id_panel);
 
     for idx in exp'range loop
       -- do not count CHECK_VALUE multiple times
@@ -5779,8 +5779,8 @@ package body methods_pkg is
   begin
     protected_check_counters.increment(CHECK_VALUE);
 
-    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope);
-    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope);
+    check_value(v_dir_check_ok = true, TB_WARNING, "array directions do not match", scope, ID_NEVER, msg_id_panel);
+    check_value(v_len_check_ok = true, TB_ERROR, "array lengths do not match", scope, ID_NEVER, msg_id_panel);
     -- do not count called CHECK_VALUE
     protected_check_counters.decrement(CHECK_VALUE, 2);
 
@@ -5833,8 +5833,8 @@ package body methods_pkg is
   begin
     protected_check_counters.increment(CHECK_VALUE);
 
-    check_value(v_dir_check_ok = true, warning, "array directions do not match", scope);
-    check_value(v_len_check_ok = true, warning, "array lengths do not match", scope);
+    check_value(v_dir_check_ok = true, warning, "array directions do not match", scope, ID_NEVER, msg_id_panel);
+    check_value(v_len_check_ok = true, warning, "array lengths do not match", scope, ID_NEVER, msg_id_panel);
     -- do not count called CHECK_VALUE
     protected_check_counters.decrement(CHECK_VALUE, 2);
 
@@ -5887,8 +5887,8 @@ package body methods_pkg is
   begin
     protected_check_counters.increment(CHECK_VALUE);
 
-    check_value(v_dir_check_ok = true, warning, "array directions do not match", scope);
-    check_value(v_len_check_ok = true, warning, "array lengths do not match", scope);
+    check_value(v_dir_check_ok = true, warning, "array directions do not match", scope, ID_NEVER, msg_id_panel);
+    check_value(v_len_check_ok = true, warning, "array lengths do not match", scope, ID_NEVER, msg_id_panel);
     -- do not count called CHECK_VALUE
     protected_check_counters.decrement(CHECK_VALUE, 2);
 


### PR DESCRIPTION
Various checking commands in VVCs caused log messages with message ID ID_POS_ACK on the default message id panel, meaning that turning off the message in the VVC message id panel didn't stop the messages from coming. I changed the checks to use the correct message id panel and also change the message ID to ID_NEVER because I don't believe we want ID_POS_ACK messages from these checks.

closes #260 