### PR TITLE
Added some missing normalizations of subprogram parameters

### DIFF
--- a/uvvm_util/src/func_cov_pkg.vhd
+++ b/uvvm_util/src/func_cov_pkg.vhd
@@ -659,16 +659,17 @@ package body func_cov_pkg is
     constant value     : integer;
     constant proc_call : string)
   return t_new_bin_array is
+    constant C_PROC_CALL_NORMALISED : string(1 to proc_call'length) := proc_call;
     variable v_ret : t_new_bin_array(0 to 0);
   begin
     v_ret(0).bin_vector(0).contains   := contains;
     v_ret(0).bin_vector(0).values(0)  := value;
     v_ret(0).bin_vector(0).num_values := 1;
     v_ret(0).num_bins                 := 1;
-    if proc_call'length > C_FC_MAX_PROC_CALL_LENGTH then
-      v_ret(0).proc_call := proc_call(1 to C_FC_MAX_PROC_CALL_LENGTH - 3) & "...";
+    if C_PROC_CALL_NORMALISED'length > C_FC_MAX_PROC_CALL_LENGTH then
+      v_ret(0).proc_call := C_PROC_CALL_NORMALISED(1 to C_FC_MAX_PROC_CALL_LENGTH - 3) & "...";
     else
-      v_ret(0).proc_call(1 to proc_call'length) := proc_call;
+      v_ret(0).proc_call(1 to C_PROC_CALL_NORMALISED'length) := C_PROC_CALL_NORMALISED;
     end if;
     return v_ret;
   end function;
@@ -679,22 +680,24 @@ package body func_cov_pkg is
     constant set_of_values : integer_vector;
     constant proc_call     : string)
   return t_new_bin_array is
-    variable v_ret : t_new_bin_array(0 to 0);
+    constant C_SET_OF_VALUES_NORMALISED : integer_vector(0 to set_of_values'length-1) := set_of_values;
+    constant C_PROC_CALL_NORMALISED     : string(1 to proc_call'length) := proc_call;
+    variable v_ret                      : t_new_bin_array(0 to 0);
   begin
     v_ret(0).bin_vector(0).contains := contains;
-    if set_of_values'length <= C_FC_MAX_NUM_BIN_VALUES then
-      v_ret(0).bin_vector(0).values(0 to set_of_values'length - 1) := set_of_values;
-      v_ret(0).bin_vector(0).num_values                            := set_of_values'length;
+    if C_SET_OF_VALUES_NORMALISED'length <= C_FC_MAX_NUM_BIN_VALUES then
+      v_ret(0).bin_vector(0).values(0 to C_SET_OF_VALUES_NORMALISED'length - 1) := C_SET_OF_VALUES_NORMALISED;
+      v_ret(0).bin_vector(0).num_values                                         := C_SET_OF_VALUES_NORMALISED'length;
     else
-      v_ret(0).bin_vector(0).values     := set_of_values(0 to C_FC_MAX_NUM_BIN_VALUES - 1);
+      v_ret(0).bin_vector(0).values     := C_SET_OF_VALUES_NORMALISED(0 to C_FC_MAX_NUM_BIN_VALUES - 1);
       v_ret(0).bin_vector(0).num_values := C_FC_MAX_NUM_BIN_VALUES;
-      alert(TB_WARNING, proc_call & "=> Number of values (" & to_string(set_of_values'length) & ") exceeds C_FC_MAX_NUM_BIN_VALUES.\n Increase C_FC_MAX_NUM_BIN_VALUES in adaptations package.", C_TB_SCOPE_DEFAULT);
+      alert(TB_WARNING, C_PROC_CALL_NORMALISED & "=> Number of values (" & to_string(C_SET_OF_VALUES_NORMALISED'length) & ") exceeds C_FC_MAX_NUM_BIN_VALUES.\n Increase C_FC_MAX_NUM_BIN_VALUES in adaptations package.", C_TB_SCOPE_DEFAULT);
     end if;
     v_ret(0).num_bins               := 1;
-    if proc_call'length > C_FC_MAX_PROC_CALL_LENGTH then
-      v_ret(0).proc_call := proc_call(1 to C_FC_MAX_PROC_CALL_LENGTH - 3) & "...";
+    if C_PROC_CALL_NORMALISED'length > C_FC_MAX_PROC_CALL_LENGTH then
+      v_ret(0).proc_call := C_PROC_CALL_NORMALISED(1 to C_FC_MAX_PROC_CALL_LENGTH - 3) & "...";
     else
-      v_ret(0).proc_call(1 to proc_call'length) := proc_call;
+      v_ret(0).proc_call(1 to C_PROC_CALL_NORMALISED'length) := C_PROC_CALL_NORMALISED;
     end if;
     return v_ret;
   end function;
@@ -707,13 +710,14 @@ package body func_cov_pkg is
     constant num_bins  : natural;
     constant proc_call : string)
   return t_new_bin_array is
-    constant C_RANGE_WIDTH     : integer := abs (max_value - min_value) + 1;
-    variable v_div_range       : integer;
-    variable v_div_residue     : integer := 0;
-    variable v_div_residue_min : integer := 0;
-    variable v_div_residue_max : integer := 0;
-    variable v_num_bins        : integer := 0;
-    variable v_ret             : t_new_bin_array(0 to 0);
+    constant C_PROC_CALL_NORMALISED : string(1 to proc_call'length) := proc_call;
+    constant C_RANGE_WIDTH          : integer := abs (max_value - min_value) + 1;
+    variable v_div_range            : integer;
+    variable v_div_residue          : integer := 0;
+    variable v_div_residue_min      : integer := 0;
+    variable v_div_residue_max      : integer := 0;
+    variable v_num_bins             : integer := 0;
+    variable v_ret                  : t_new_bin_array(0 to 0);
   begin
     check_value(contains = RAN or contains = RAN_IGNORE or contains = RAN_ILLEGAL, TB_FAILURE, "This function should only be used with range types.",
                 C_TB_SCOPE_DEFAULT, ID_NEVER, caller_name => "create_bin_range()");
@@ -722,7 +726,7 @@ package body func_cov_pkg is
       -- Create a bin for each value in the range (when num_bins is not defined or range is smaller than the number of bins)
       if num_bins = 0 or C_RANGE_WIDTH <= num_bins then
         if C_RANGE_WIDTH > C_FC_MAX_NUM_NEW_BINS then
-          alert(TB_ERROR, proc_call & "=> Failed. Number of bins (" & to_string(C_RANGE_WIDTH) & ") added in a single procedure call exceeds C_FC_MAX_NUM_NEW_BINS.\n Increase C_FC_MAX_NUM_NEW_BINS in adaptations package.", C_TB_SCOPE_DEFAULT);
+          alert(TB_ERROR, C_PROC_CALL_NORMALISED & "=> Failed. Number of bins (" & to_string(C_RANGE_WIDTH) & ") added in a single procedure call exceeds C_FC_MAX_NUM_NEW_BINS.\n Increase C_FC_MAX_NUM_NEW_BINS in adaptations package.", C_TB_SCOPE_DEFAULT);
           return C_EMPTY_NEW_BIN_ARRAY;
         end if;
         for i in min_value to max_value loop
@@ -736,7 +740,7 @@ package body func_cov_pkg is
       -- Create several bins by diving the range
       else
         if num_bins > C_FC_MAX_NUM_NEW_BINS then
-          alert(TB_ERROR, proc_call & "=> Failed. Number of bins (" & to_string(num_bins) & ") added in a single procedure call exceeds C_FC_MAX_NUM_NEW_BINS.\n Increase C_FC_MAX_NUM_NEW_BINS in adaptations package.", C_TB_SCOPE_DEFAULT);
+          alert(TB_ERROR, C_PROC_CALL_NORMALISED & "=> Failed. Number of bins (" & to_string(num_bins) & ") added in a single procedure call exceeds C_FC_MAX_NUM_NEW_BINS.\n Increase C_FC_MAX_NUM_NEW_BINS in adaptations package.", C_TB_SCOPE_DEFAULT);
           return C_EMPTY_NEW_BIN_ARRAY;
         end if;
         v_div_residue := C_RANGE_WIDTH mod num_bins;
@@ -757,13 +761,13 @@ package body func_cov_pkg is
         end loop;
       end if;
       v_ret(0).num_bins := v_num_bins;
-      if proc_call'length > C_FC_MAX_PROC_CALL_LENGTH then
-        v_ret(0).proc_call := proc_call(1 to C_FC_MAX_PROC_CALL_LENGTH - 3) & "...";
+      if C_PROC_CALL_NORMALISED'length > C_FC_MAX_PROC_CALL_LENGTH then
+        v_ret(0).proc_call := C_PROC_CALL_NORMALISED(1 to C_FC_MAX_PROC_CALL_LENGTH - 3) & "...";
       else
-        v_ret(0).proc_call(1 to proc_call'length) := proc_call;
+        v_ret(0).proc_call(1 to C_PROC_CALL_NORMALISED'length) := C_PROC_CALL_NORMALISED;
       end if;
     else
-      alert(TB_ERROR, proc_call & "=> Failed. min_value must be less or equal than max_value", C_TB_SCOPE_DEFAULT);
+      alert(TB_ERROR, C_PROC_CALL_NORMALISED & "=> Failed. min_value must be less or equal than max_value", C_TB_SCOPE_DEFAULT);
       return C_EMPTY_NEW_BIN_ARRAY;
     end if;
     return v_ret;
@@ -1217,14 +1221,15 @@ package body func_cov_pkg is
       constant bin_name : string;
       constant bin_idx  : string)
     return string is
+      constant C_BIN_NAME_NORMALISED : string(1 to bin_name'length) := bin_name;
     begin
-      if bin_name = "" then
+      if C_BIN_NAME_NORMALISED = "" then
         return "bin_" & bin_idx & fill_string(NUL, C_FC_MAX_NAME_LENGTH - 4 - bin_idx'length);
       else
-        if bin_name'length > C_FC_MAX_NAME_LENGTH then
-          return bin_name(1 to C_FC_MAX_NAME_LENGTH);
+        if C_BIN_NAME_NORMALISED'length > C_FC_MAX_NAME_LENGTH then
+          return C_BIN_NAME_NORMALISED(1 to C_FC_MAX_NAME_LENGTH);
         else
-          return bin_name & fill_string(NUL, C_FC_MAX_NAME_LENGTH - bin_name'length);
+          return C_BIN_NAME_NORMALISED & fill_string(NUL, C_FC_MAX_NAME_LENGTH - C_BIN_NAME_NORMALISED'length);
         end if;
       end if;
     end function;
@@ -1632,12 +1637,13 @@ package body func_cov_pkg is
     ------------------------------------------------------------
     procedure set_name(
       constant name : in string) is
-      constant C_LOCAL_CALL : string := "set_name(" & name & ")";
+      constant C_NAME_NORMALISED  : string(1 to name'length) := name;
+      constant C_LOCAL_CALL       : string := "set_name(" & name & ")";
     begin
-      if name'length > C_FC_MAX_NAME_LENGTH then
-        priv_name := name(1 to C_FC_MAX_NAME_LENGTH);
+      if C_NAME_NORMALISED'length > C_FC_MAX_NAME_LENGTH then
+        priv_name := C_NAME_NORMALISED(1 to C_FC_MAX_NAME_LENGTH);
       else
-        priv_name := name & fill_string(NUL, C_FC_MAX_NAME_LENGTH - name'length);
+        priv_name := C_NAME_NORMALISED & fill_string(NUL, C_FC_MAX_NAME_LENGTH - C_NAME_NORMALISED'length);
       end if;
       initialize_coverpoint(C_LOCAL_CALL);
       protected_covergroup_status.set_name(priv_id, priv_name);
@@ -1652,13 +1658,14 @@ package body func_cov_pkg is
 
     procedure set_scope(
       constant scope : in string) is
-      constant C_LOCAL_CALL : string := "set_scope(" & scope & ")";
+      constant C_SCOPE_NORMALISED : string(1 to scope'length) := scope;
+      constant C_LOCAL_CALL       : string := "set_scope(" & scope & ")";
     begin
       initialize_coverpoint(C_LOCAL_CALL);
-      if scope'length > C_LOG_SCOPE_WIDTH then
-        priv_scope := scope(1 to C_LOG_SCOPE_WIDTH);
+      if C_SCOPE_NORMALISED'length > C_LOG_SCOPE_WIDTH then
+        priv_scope := C_SCOPE_NORMALISED(1 to C_LOG_SCOPE_WIDTH);
       else
-        priv_scope := scope & fill_string(NUL, C_LOG_SCOPE_WIDTH - scope'length);
+        priv_scope := C_SCOPE_NORMALISED & fill_string(NUL, C_LOG_SCOPE_WIDTH - C_SCOPE_NORMALISED'length);
       end if;
     end procedure;
 

--- a/uvvm_util/src/generic_queue_pkg.vhd
+++ b/uvvm_util/src/generic_queue_pkg.vhd
@@ -545,24 +545,26 @@ package body generic_queue_pkg is
 
     procedure set_scope(
       constant instance : in integer;
-      constant scope    : in string) is
+      constant scope    : in string
+    ) is
+      constant C_SCOPE_NORMALISED : string(1 to scope'length) := scope;
     begin
       if instance = ALL_INSTANCES then
-        if scope'length > C_LOG_SCOPE_WIDTH then
-          priv_scope := (others => scope(1 to C_LOG_SCOPE_WIDTH));
+        if C_SCOPE_NORMALISED'length > C_LOG_SCOPE_WIDTH then
+          priv_scope := (others => C_SCOPE_NORMALISED(1 to C_LOG_SCOPE_WIDTH));
         else
           for idx in priv_scope'range loop
-            priv_scope(idx)                    := (others => NUL);
-            priv_scope(idx)(1 to scope'length) := scope;
+            priv_scope(idx)                                 := (others => NUL);
+            priv_scope(idx)(1 to C_SCOPE_NORMALISED'length) := C_SCOPE_NORMALISED;
           end loop;
         end if;
         priv_scope_is_defined := (others => true);
       else
-        if scope'length > C_LOG_SCOPE_WIDTH then
-          priv_scope(instance) := scope(1 to C_LOG_SCOPE_WIDTH);
+        if C_SCOPE_NORMALISED'length > C_LOG_SCOPE_WIDTH then
+          priv_scope(instance) := C_SCOPE_NORMALISED(1 to C_LOG_SCOPE_WIDTH);
         else
-          priv_scope(instance)                    := (others => NUL);
-          priv_scope(instance)(1 to scope'length) := scope;
+          priv_scope(instance)                                  := (others => NUL);
+          priv_scope(instance)(1 to C_SCOPE_NORMALISED'length)  := C_SCOPE_NORMALISED;
         end if;
         priv_scope_is_defined(instance) := true;
       end if;

--- a/uvvm_util/src/methods_pkg.vhd
+++ b/uvvm_util/src/methods_pkg.vhd
@@ -3555,6 +3555,7 @@ package body methods_pkg is
     log_file_name   : string            := C_LOG_FILE_NAME;
     open_mode       : file_open_kind    := append_mode
   ) is
+    constant C_MSG_NORMALISED     : string(1 to msg'length) := msg;
     variable v_msg               : line;
     variable v_msg_indent        : line;
     variable v_msg_indent_width  : natural;
@@ -3589,7 +3590,7 @@ package body methods_pkg is
       if msg'length > 1 then
         if C_USE_BACKSLASH_R_AS_LF then
           loop
-            if (msg(v_idx to v_idx + 1) = "\r") then
+            if (C_MSG_NORMALISED(v_idx to v_idx + 1) = "\r") then
               write(v_info_final, LF); -- Start transcript with an empty line
               v_idx := v_idx + 2;
             else
@@ -4722,10 +4723,11 @@ package body methods_pkg is
 
     -- Match length of short string with long string
     function pad_short_string(short, long : string) return string is
-      variable v_padding                    : string(1 to (long'length - short'length)) := (others => '0');
+      constant C_SHORT_NORMALISED : string(1 to short'length) := short;
+      variable v_padding          : string(1 to (long'length - short'length)) := (others => '0');
     begin
       -- Include leading 'x"'
-      return short(1 to 2) & v_padding & short(3 to short'length);
+      return C_SHORT_NORMALISED(1 to 2) & v_padding & C_SHORT_NORMALISED(3 to short'length);
     end function;
 
     -- Function to represent signed value as string if value_type is "signed"
@@ -7223,11 +7225,13 @@ package body methods_pkg is
   ) is
     variable v_length : integer := v_target'length;
     variable v_rand   : integer;
+    variable v_bit    : std_logic_vector(0 downto 0);
   begin
     -- Iterate through each bit and randomly set to 0 or 1
     for i in 0 to v_length - 1 loop
       random(0, 1, v_seed1, v_seed2, v_rand);
-      v_target(i downto i) := std_logic_vector(to_unsigned(v_rand, 1));
+      v_bit       := std_logic_vector(to_unsigned(v_rand, 1));
+      v_target(i) := v_bit(0);
     end loop;
   end procedure;
 

--- a/uvvm_util/src/protected_types_pkg.vhd
+++ b/uvvm_util/src/protected_types_pkg.vhd
@@ -331,12 +331,14 @@ package body protected_types_pkg is
 
     procedure set_name(
       constant coverpoint_idx : in integer;
-      constant name           : in string) is
+      constant name           : in string
+    ) is
+      constant C_NAME_NORMALISED  : string(1 to name'length) := name;
     begin
-      if name'length > C_FC_MAX_NAME_LENGTH then
-        priv_coverpoint_status_list(coverpoint_idx).name := name(1 to C_FC_MAX_NAME_LENGTH);
+      if C_NAME_NORMALISED'length > C_FC_MAX_NAME_LENGTH then
+        priv_coverpoint_status_list(coverpoint_idx).name := C_NAME_NORMALISED(1 to C_FC_MAX_NAME_LENGTH);
       else
-        priv_coverpoint_status_list(coverpoint_idx).name := name & fill_string(NUL, C_FC_MAX_NAME_LENGTH - name'length);
+        priv_coverpoint_status_list(coverpoint_idx).name := C_NAME_NORMALISED & fill_string(NUL, C_FC_MAX_NAME_LENGTH - C_NAME_NORMALISED'length);
       end if;
     end procedure;
 

--- a/uvvm_util/src/rand_pkg.vhd
+++ b/uvvm_util/src/rand_pkg.vhd
@@ -2045,12 +2045,14 @@ package body rand_pkg is
     -- Configuration
     ------------------------------------------------------------
     procedure set_name(
-      constant name : in string) is
+      constant name : in string
+    ) is
+      constant C_NAME_NORMALISED : string(1 to name'length) := name;
     begin
-      if name'length > C_RAND_MAX_NAME_LENGTH then
-        priv_name := name(1 to C_RAND_MAX_NAME_LENGTH);
+      if C_NAME_NORMALISED'length > C_RAND_MAX_NAME_LENGTH then
+        priv_name := C_NAME_NORMALISED(1 to C_RAND_MAX_NAME_LENGTH);
       else
-        priv_name := name & fill_string(NUL, C_RAND_MAX_NAME_LENGTH - name'length);
+        priv_name := C_NAME_NORMALISED & fill_string(NUL, C_RAND_MAX_NAME_LENGTH - C_NAME_NORMALISED'length);
       end if;
     end procedure;
 
@@ -2062,12 +2064,14 @@ package body rand_pkg is
     end function;
 
     procedure set_scope(
-      constant scope : in string) is
+      constant scope : in string
+    ) is
+      constant C_SCOPE_NORMALISED : string(1 to scope'length) := scope;
     begin
-      if scope'length > C_LOG_SCOPE_WIDTH then
-        priv_scope := scope(1 to C_LOG_SCOPE_WIDTH);
+      if C_SCOPE_NORMALISED'length > C_LOG_SCOPE_WIDTH then
+        priv_scope := C_SCOPE_NORMALISED(1 to C_LOG_SCOPE_WIDTH);
       else
-        priv_scope := scope & fill_string(NUL, C_LOG_SCOPE_WIDTH - scope'length);
+        priv_scope := C_SCOPE_NORMALISED & fill_string(NUL, C_LOG_SCOPE_WIDTH - C_SCOPE_NORMALISED'length);
       end if;
     end procedure;
 

--- a/uvvm_vvc_framework/src/ti_generic_queue_pkg.vhd
+++ b/uvvm_vvc_framework/src/ti_generic_queue_pkg.vhd
@@ -547,23 +547,24 @@ package body ti_generic_queue_pkg is
     procedure set_scope(
       constant instance : in integer;
       constant scope    : in string) is
+      constant C_SCOPE_NORMALISED : string(1 to scope'length) := scope;
     begin
       if instance = ALL_INSTANCES then
-        if scope'length > C_LOG_SCOPE_WIDTH then
-          v_scope := (others => scope(1 to C_LOG_SCOPE_WIDTH));
+        if C_SCOPE_NORMALISED'length > C_LOG_SCOPE_WIDTH then
+          v_scope := (others => C_SCOPE_NORMALISED(1 to C_LOG_SCOPE_WIDTH));
         else
           for idx in v_scope'range loop
-            v_scope(idx)                    := (others => NUL);
-            v_scope(idx)(1 to scope'length) := scope;
+            v_scope(idx)                                 := (others => NUL);
+            v_scope(idx)(1 to C_SCOPE_NORMALISED'length) := C_SCOPE_NORMALISED;
           end loop;
         end if;
         v_scope_is_defined := (others => true);
       else
-        if scope'length > C_LOG_SCOPE_WIDTH then
-          v_scope(instance) := scope(1 to C_LOG_SCOPE_WIDTH);
+        if C_SCOPE_NORMALISED'length > C_LOG_SCOPE_WIDTH then
+          v_scope(instance) := C_SCOPE_NORMALISED(1 to C_LOG_SCOPE_WIDTH);
         else
-          v_scope(instance)                    := (others => NUL);
-          v_scope(instance)(1 to scope'length) := scope;
+          v_scope(instance)                                 := (others => NUL);
+          v_scope(instance)(1 to C_SCOPE_NORMALISED'length) := C_SCOPE_NORMALISED;
         end if;
         v_scope_is_defined(instance) := true;
       end if;

--- a/uvvm_vvc_framework/src/ti_vvc_framework_support_pkg.vhd
+++ b/uvvm_vvc_framework/src/ti_vvc_framework_support_pkg.vhd
@@ -738,8 +738,10 @@ package body ti_vvc_framework_support_pkg is
     constant instance_idx : natural;
     constant channel      : t_channel
   ) return string is
+    constant C_VVC_NAME_NORMALISED       : string(1 to vvc_name'length) := vvc_name;
     constant C_INSTANCE_IDX_STR          : string  := to_string(instance_idx);
-    constant C_CHANNEL_STR               : string  := to_upper(to_string(channel));
+    constant C_CHANNEL_STR               : string := to_upper(to_string(channel));
+    constant C_CHANNEL_STR_NORMALISED    : string(1 to C_CHANNEL_STR'length) := C_CHANNEL_STR;
     constant C_SCOPE_LENGTH              : natural := vvc_name'length + C_INSTANCE_IDX_STR'length + C_CHANNEL_STR'length + 2; -- +2 because of the two added commas
     variable v_vvc_name_truncation_value : integer;
     variable v_channel_truncation_value  : integer;
@@ -753,24 +755,24 @@ package body ti_vvc_framework_support_pkg is
 
     -- If C_SCOPE_LENGTH is not greater than allowed width, return scope
     if C_SCOPE_LENGTH <= C_LOG_SCOPE_WIDTH then
-      return vvc_name & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR;
+      return C_VVC_NAME_NORMALISED & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR_NORMALISED;
 
     -- If C_SCOPE_LENGTH is greater than allowed width
 
     -- Check if vvc_name is greater than minimum width to truncate
-    elsif vvc_name'length <= C_MINIMUM_VVC_NAME_SCOPE_WIDTH then
-      return vvc_name & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR(1 to (C_CHANNEL_STR'length - (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH)));
+    elsif C_VVC_NAME_NORMALISED'length <= C_MINIMUM_VVC_NAME_SCOPE_WIDTH then
+      return C_VVC_NAME_NORMALISED & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR_NORMALISED(1 to (C_CHANNEL_STR_NORMALISED'length - (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH)));
 
     -- Check if channel is greater than minimum width to truncate
-    elsif C_CHANNEL_STR'length <= C_MINIMUM_CHANNEL_SCOPE_WIDTH then
-      return vvc_name(1 to (vvc_name'length - (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR;
+    elsif C_CHANNEL_STR_NORMALISED'length <= C_MINIMUM_CHANNEL_SCOPE_WIDTH then
+      return C_VVC_NAME_NORMALISED(1 to (C_VVC_NAME_NORMALISED'length - (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR_NORMALISED;
 
     -- If both vvc_name and channel is to be truncated
     else
 
       -- Calculate linear scaling of truncation between vvc_name and channel: (a*x)/(a+b), (b*x)/(a+b)
-      v_vvc_name_truncation_idx  := integer(round(real(vvc_name'length * (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) / real(vvc_name'length + C_CHANNEL_STR'length));
-      v_channel_truncation_value := integer(round(real(C_CHANNEL_STR'length * (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) / real(vvc_name'length + C_CHANNEL_STR'length));
+      v_vvc_name_truncation_idx  := integer(round(real(C_VVC_NAME_NORMALISED'length * (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) / real(C_VVC_NAME_NORMALISED'length + C_CHANNEL_STR_NORMALISED'length));
+      v_channel_truncation_value := integer(round(real(C_CHANNEL_STR_NORMALISED'length * (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) / real(C_VVC_NAME_NORMALISED'length + C_CHANNEL_STR_NORMALISED'length));
 
       -- In case division ended with .5 and both rounded up
       if (v_vvc_name_truncation_idx + v_channel_truncation_value) > (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH) then
@@ -778,8 +780,8 @@ package body ti_vvc_framework_support_pkg is
       end if;
 
       -- Character index to truncate
-      v_vvc_name_truncation_idx := vvc_name'length - v_vvc_name_truncation_idx;
-      v_channel_truncation_idx  := C_CHANNEL_STR'length - v_channel_truncation_value;
+      v_vvc_name_truncation_idx := C_VVC_NAME_NORMALISED'length - v_vvc_name_truncation_idx;
+      v_channel_truncation_idx  := C_CHANNEL_STR_NORMALISED'length - v_channel_truncation_value;
 
       -- If bellow minimum name width
       while v_vvc_name_truncation_idx < C_MINIMUM_VVC_NAME_SCOPE_WIDTH loop
@@ -793,7 +795,7 @@ package body ti_vvc_framework_support_pkg is
         v_vvc_name_truncation_idx := v_vvc_name_truncation_idx - 1;
       end loop;
 
-      return vvc_name(1 to v_vvc_name_truncation_idx) & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR(1 to v_channel_truncation_idx);
+      return C_VVC_NAME_NORMALISED(1 to v_vvc_name_truncation_idx) & "," & C_INSTANCE_IDX_STR & "," & C_CHANNEL_STR_NORMALISED(1 to v_channel_truncation_idx);
 
     end if;
   end function;
@@ -802,8 +804,9 @@ package body ti_vvc_framework_support_pkg is
     constant vvc_name     : string;
     constant instance_idx : natural
   ) return string is
-    constant C_INSTANCE_IDX_STR : string  := to_string(instance_idx);
-    constant C_SCOPE_LENGTH     : integer := vvc_name'length + C_INSTANCE_IDX_STR'length + 1; -- +1 because of the added comma
+    constant C_VVC_NAME_NORMALISED  : string(1 to vvc_name'length) := vvc_name;
+    constant C_INSTANCE_IDX_STR     : string  := to_string(instance_idx);
+    constant C_SCOPE_LENGTH         : integer := vvc_name'length + C_INSTANCE_IDX_STR'length + 1; -- +1 because of the added comma
   begin
 
     if (C_MINIMUM_VVC_NAME_SCOPE_WIDTH + C_INSTANCE_IDX_STR'length + 1) > C_LOG_SCOPE_WIDTH then -- +1 because of the added comma
@@ -812,11 +815,11 @@ package body ti_vvc_framework_support_pkg is
 
     -- If C_SCOPE_LENGTH is not greater than allowed width, return scope
     if C_SCOPE_LENGTH <= C_LOG_SCOPE_WIDTH then
-      return vvc_name & "," & C_INSTANCE_IDX_STR;
+      return C_VVC_NAME_NORMALISED & "," & C_INSTANCE_IDX_STR;
 
     -- If C_SCOPE_LENGTH is greater than allowed width truncate vvc_name
     else
-      return vvc_name(1 to (vvc_name'length - (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) & "," & C_INSTANCE_IDX_STR;
+      return C_VVC_NAME_NORMALISED(1 to (C_VVC_NAME_NORMALISED'length - (C_SCOPE_LENGTH - C_LOG_SCOPE_WIDTH))) & "," & C_INSTANCE_IDX_STR;
 
     end if;
   end function;

--- a/uvvm_vvc_framework/src_target_dependent/td_vvc_entity_support_pkg.vhd
+++ b/uvvm_vvc_framework/src_target_dependent/td_vvc_entity_support_pkg.vhd
@@ -375,6 +375,7 @@ package body td_vvc_entity_support_pkg is
     constant result_queue_count_threshold_severity : in t_alert_level;
     constant max_vvc_instance_num                  : in natural := C_MAX_VVC_INSTANCE_NUM
   ) is
+    constant C_SCOPE_NORMALISED    : string(1 to scope'length) := scope;
     variable v_delta_cycle_counter : natural := 0;
     variable v_comma_number        : natural := 0;
   begin
@@ -382,32 +383,32 @@ package body td_vvc_entity_support_pkg is
     vvc_config.bfm_config := bfm_config;
 
     -- compose log message based on the number of channels in scope string
-    if pos_of_leftmost(',', scope, 1) = pos_of_rightmost(',', scope, 1) then
-      log(ID_CONSTRUCTOR, "VVC instantiated.", scope, vvc_config.msg_id_panel);
+    if pos_of_leftmost(',', C_SCOPE_NORMALISED, 1) = pos_of_rightmost(',', C_SCOPE_NORMALISED, 1) then
+      log(ID_CONSTRUCTOR, "VVC instantiated.", C_SCOPE_NORMALISED, vvc_config.msg_id_panel);
     else
-      for idx in scope'range loop
-        if (scope(idx) = ',') and (v_comma_number < 2) then -- locate 2nd comma in string
+      for idx in C_SCOPE_NORMALISED'range loop
+        if (C_SCOPE_NORMALISED(idx) = ',') and (v_comma_number < 2) then -- locate 2nd comma in string
           v_comma_number := v_comma_number + 1;
         end if;
         if v_comma_number = 2 then      -- rest of string is channel name
-          log(ID_CONSTRUCTOR, "VVC instantiated for channel " & scope((idx + 1) to scope'length), scope, vvc_config.msg_id_panel);
+          log(ID_CONSTRUCTOR, "VVC instantiated for channel " & C_SCOPE_NORMALISED((idx + 1) to C_SCOPE_NORMALISED'length), C_SCOPE_NORMALISED, vvc_config.msg_id_panel);
           exit;
         end if;
       end loop;
     end if;
-    command_queue.set_scope(scope);
+    command_queue.set_scope(C_SCOPE_NORMALISED);
     command_queue.set_name("cmd_queue");
     command_queue.set_queue_count_max(cmd_queue_count_max);
     command_queue.set_queue_count_threshold(cmd_queue_count_threshold);
     command_queue.set_queue_count_threshold_severity(cmd_queue_count_threshold_severity);
-    log(ID_CONSTRUCTOR_SUB, "Command queue instantiated and will give a warning when reaching " & to_string(command_queue.get_queue_count_max(VOID)) & " elements in queue.", scope, vvc_config.msg_id_panel);
+    log(ID_CONSTRUCTOR_SUB, "Command queue instantiated and will give a warning when reaching " & to_string(command_queue.get_queue_count_max(VOID)) & " elements in queue.", C_SCOPE_NORMALISED, vvc_config.msg_id_panel);
 
-    result_queue.set_scope(scope);
+    result_queue.set_scope(C_SCOPE_NORMALISED);
     result_queue.set_name("result_queue");
     result_queue.set_queue_count_max(result_queue_count_max);
     result_queue.set_queue_count_threshold(result_queue_count_threshold);
     result_queue.set_queue_count_threshold_severity(result_queue_count_threshold_severity);
-    log(ID_CONSTRUCTOR_SUB, "Result queue instantiated and will give a warning when reaching " & to_string(result_queue.get_queue_count_max(VOID)) & " elements in queue.", scope, vvc_config.msg_id_panel);
+    log(ID_CONSTRUCTOR_SUB, "Result queue instantiated and will give a warning when reaching " & to_string(result_queue.get_queue_count_max(VOID)) & " elements in queue.", C_SCOPE_NORMALISED, vvc_config.msg_id_panel);
 
     if shared_uvvm_state /= PHASE_A then
       loop


### PR DESCRIPTION
Fixed all of the warnings that seemed unsafe from #268. 

Some of the warnings are not actually unsafe. For instance multiple places where access types are generated with the new keyword with a specific range. However, this still causes the warning about "unknown direction"

closes #268